### PR TITLE
fix build on current systems

### DIFF
--- a/src/fatx.h
+++ b/src/fatx.h
@@ -20,7 +20,11 @@
 #ifndef FATX_H
 #define FATX_H
 
-#define _XOPEN_SOURCE
+#if __STDC_VERSION__ >= 199901L
+#define _XOPEN_SOURCE 600
+#else
+#define _XOPEN_SOURCE 500
+#endif /* __STDC_VERSION__ */
 
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
`_XOPEN_SOURCE` has to be set to [some number](https://stackoverflow.com/questions/5378778/what-does-d-xopen-source-do-mean?answertab=votes#tab-top) for `struct timespec` to be defined on newer systems. Let's do so to make it compile again.

fixes #3