### PR TITLE
Adds retail & f-takes-all disk formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/src)
 add_definitions("-ansi -Wall --std=c99 -pedantic")
 add_library(fatx ${FATX_SOURCES})
 
-if(FUSE_MODULE_NAME)
+if(FUSE_FOUND)
     add_executable(fatxfs ${FATXFS_SOURCES})
     target_link_libraries(fatxfs fatx ${FUSE_LDFLAGS})
     target_include_directories(fatxfs PUBLIC ${FUSE_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(FATX_SOURCES "")
 set(FATXFS_SOURCES "")
 add_subdirectory(${CMAKE_SOURCE_DIR}/src)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_definitions("-ansi -Wall --std=c99 -pedantic")
 add_library(fatx ${FATX_SOURCES})
 

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -88,7 +88,7 @@ def ffibuilder():
 
         struct fatx_fs *pyfatx_open_helper(void);
 
-        int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t size, size_t sector_size);
+        int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t size, size_t sector_size, size_t sectors_per_cluster);
         int fatx_close_device(struct fatx_fs *fs);
         int fatx_open_dir(struct fatx_fs *fs, char const *path, struct fatx_dir *dir);
         int fatx_read_dir(struct fatx_fs *fs, struct fatx_dir *dir, struct fatx_dirent *entry, struct fatx_attr *attr, struct fatx_dirent **result);

--- a/pyfatx/__init__.py
+++ b/pyfatx/__init__.py
@@ -60,12 +60,12 @@ class Fatx:
 				'y': (0x2ee80000, 0x02ee00000),
 				'z': (0x5dc80000, 0x02ee00000),
 				'c': (0x8ca80000, 0x01f400000),
-				'e': (0xabe80000, 0x131f00000),
+				'e': (0xabe80000, 0x1312d6000),
 			}
 			offset, size = partitions[drive]
 		if isinstance(path, str):
 			path = path.encode('utf-8')
-		s = fatx_open_device(self.fs, path, offset, size, sector_size)
+		s = fatx_open_device(self.fs, path, offset, size, sector_size, 0)
 		if s != 0:
 			self.fs = None
 		assert s == 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FATX_SOURCES ${FATX_SOURCES}
                  ${CMAKE_CURRENT_SOURCE_DIR}/fatx_attr.c
                  ${CMAKE_CURRENT_SOURCE_DIR}/fatx_dev.c
                  ${CMAKE_CURRENT_SOURCE_DIR}/fatx_dir.c
+                 ${CMAKE_CURRENT_SOURCE_DIR}/fatx_disk.c
                  ${CMAKE_CURRENT_SOURCE_DIR}/fatx_fat.c
                  ${CMAKE_CURRENT_SOURCE_DIR}/fatx_file.c
                  ${CMAKE_CURRENT_SOURCE_DIR}/fatx_internal.h

--- a/src/fatx.c
+++ b/src/fatx.c
@@ -97,7 +97,7 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t
             break;
 
         default:
-            fatx_error(fs, "%d sectors per cluster exceeds limit\n", fs->sectors_per_cluster);
+            fatx_error(fs, "invalid sectors per cluster %d\n", fs->sectors_per_cluster);
             retval = FATX_STATUS_ERROR;
             goto cleanup;
     }

--- a/src/fatx.c
+++ b/src/fatx.c
@@ -168,33 +168,3 @@ int fatx_close_device(struct fatx_fs *fs)
     fclose(fs->device);
     return FATX_STATUS_SUCCESS;
 }
-
-/*
- * Return the disk length (in bytes).
- */
-int fatx_disk_size(char const *path, uint64_t *size)
-{
-    FILE * device;
-    int retval;
-
-    device = fopen(path, "r");
-    if (!device)
-    {
-        fprintf(stderr, "failed to open %s for size query\n", path);
-        return FATX_STATUS_ERROR;
-    }
-
-    if (fseek(device, 0, SEEK_END))
-    {
-        fprintf(stderr, "failed to seek to end of disk\n");
-        retval = FATX_STATUS_ERROR;
-        goto cleanup;
-    }
-
-    *size = ftell(device);
-    retval = FATX_STATUS_SUCCESS;
-
-cleanup:
-    fclose(device);
-    return retval;
-}

--- a/src/fatx.c
+++ b/src/fatx.c
@@ -63,24 +63,9 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t
         return FATX_STATUS_ERROR;
     }
 
-    /* Initialize device with existing FATX superblock. */
-    if (sectors_per_cluster == 0)
+    if (fatx_init_superblock(fs, sectors_per_cluster))
     {
-        if (fatx_check_partition_signature(fs) || fatx_read_superblock(fs))
-        {
-            retval = FATX_STATUS_ERROR;
-            goto cleanup;
-        }
-    }
-
-    /* Initialize device with a new FATX superblock. */
-    else
-    {
-        if (fatx_init_superblock(fs, sectors_per_cluster))
-        {
-            retval = FATX_STATUS_ERROR;
-            goto cleanup;
-        }
+        return FATX_STATUS_ERROR;
     }
 
     /* Validate that an acceptable cluster+sector combo was configured */

--- a/src/fatx.c
+++ b/src/fatx.c
@@ -38,11 +38,21 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t
         return FATX_STATUS_ERROR;
     }
 
-    /* Sanity check partition offset and size. */
     if (offset % sector_size)
     {
-        fatx_error(fs, "specified partition offset does not reside on sector boundary (%d bytes)\n", sector_size);
+        fatx_error(fs, "specified partition offset (0x%zx) does not reside on sector boundary (%d bytes)\n", offset, sector_size);
         return FATX_STATUS_ERROR;
+    }
+
+    /* Compute partition size as remaining disk space */
+    if (size == -1)
+    {
+        if(fatx_disk_size_remaining(path, offset, &size))
+        {
+            fatx_error(fs, "failed to resolve partition size");
+            return FATX_STATUS_ERROR;
+        }
+        size &= ~(sector_size - 1);
     }
 
     if (size % sector_size)

--- a/src/fatx.c
+++ b/src/fatx.c
@@ -44,10 +44,10 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t
         return FATX_STATUS_ERROR;
     }
 
-    /* Compute partition size as remaining disk space */
+    /* Compute partition size using remaining disk space and align down to nearest sector */
     if (size == -1)
     {
-        if(fatx_disk_size_remaining(path, offset, &size))
+        if (fatx_disk_size_remaining(path, offset, &size))
         {
             fatx_error(fs, "failed to resolve partition size");
             return FATX_STATUS_ERROR;

--- a/src/fatx.c
+++ b/src/fatx.c
@@ -88,7 +88,10 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t
         case 16:
         case 32:
         case 64:
-        case 128:
+        case 128: // retail max
+        case 256:
+        case 512:
+        case 1024:
             break;
 
         default:
@@ -138,7 +141,7 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, size_t offset, size_t
     fatx_info(fs, "  Partition Size:      0x%zx bytes\n", fs->partition_size);
     fatx_info(fs, "  Volume Id:           %.8x\n",        fs->volume_id);
     fatx_info(fs, "  Bytes per Sector:    %d\n",          fs->sector_size);
-    fatx_info(fs, "  # of Sectors:        %d\n",          fs->num_sectors);
+    fatx_info(fs, "  # of Sectors:        %llu\n",        fs->num_sectors);
     fatx_info(fs, "  Sectors per Cluster: %d\n",          fs->sectors_per_cluster);
     fatx_info(fs, "  # of Clusters:       %d\n",          fs->num_clusters);
     fatx_info(fs, "  Bytes per Cluster:   %d\n",          fs->bytes_per_cluster);

--- a/src/fatx.h
+++ b/src/fatx.h
@@ -137,9 +137,10 @@ void fatx_time_t_to_fatx_ts(const time_t in, struct fatx_ts *out);
 time_t fatx_ts_to_time_t(struct fatx_ts *in);
 
 /* Disk Functions */
-int fatx_disk_size(char const *path, uint64_t *size);
+int fatx_disk_size(char const *path, size_t *size);
+int fatx_disk_size_remaining(char const *path, size_t offset, size_t *size);
 int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, enum fatx_format format_type, size_t sectors_per_cluster);
-int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster);
+int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, size_t offset, size_t size, size_t sector_size, size_t sectors_per_cluster);
 int fatx_drive_to_offset_size(char drive_letter, size_t *offset, size_t *size);
 int fatx_disk_read_refurb_info(char const *path);
 int fatx_disk_write_refurb_info(char const *path, uint32_t number_of_boots, uint64_t first_power_on);

--- a/src/fatx.h
+++ b/src/fatx.h
@@ -67,7 +67,7 @@ struct fatx_fs {
     size_t      partition_offset;
     size_t      partition_size;
     uint32_t    volume_id;
-    uint32_t    num_sectors;
+    uint64_t    num_sectors;
     uint32_t    num_clusters;
     uint32_t    sectors_per_cluster;
     uint8_t     fat_type;

--- a/src/fatx.h
+++ b/src/fatx.h
@@ -139,5 +139,7 @@ int fatx_disk_size(char const *path, uint64_t *size);
 int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, enum fatx_format format_type, size_t sectors_per_cluster);
 int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster);
 int fatx_drive_to_offset_size(char drive_letter, size_t *offset, size_t *size);
+int fatx_disk_read_refurb_info(char const *path);
+int fatx_disk_write_refurb_info(char const *path, uint32_t number_of_boots, uint64_t first_power_on);
 
 #endif

--- a/src/fatx.h
+++ b/src/fatx.h
@@ -43,7 +43,7 @@
 #define FATX_STATUS_FILE_DELETED     1
 #define FATX_STATUS_END_OF_DIR       2
 
-#define FATX_RETAIL_CLUSTER_SIZE     16 * 1024
+#define FATX_RETAIL_CLUSTER_SIZE     (16 * 1024)
 #define FATX_RETAIL_PARTITION_COUNT  5
 
 struct fatx_fs {

--- a/src/fatx.h
+++ b/src/fatx.h
@@ -46,6 +46,18 @@
 #define FATX_RETAIL_CLUSTER_SIZE     (16 * 1024)
 #define FATX_RETAIL_PARTITION_COUNT  5
 
+/*
+ * This define should always be passed to fatx_open_device(...) as the
+ * sectors_per_cluster argument when opening existing FATX filesystems.
+ *
+ * It is a special value designed to tell fatx_open_device(...) that it
+ * must read the superblock of the FATX partition being opened to determine
+ * how many sectors_per_cluster the partition was formatted with.
+ *
+ * The cases where this define is NOT passed to fatx_open_device(...) is
+ * when formatting a new disk. In this case, the caller is expected to pass
+ * pass a valid non-zero sectors_per_cluster to format the partition with.
+ */
 #define FATX_READ_FROM_SUPERBLOCK    0
 
 struct fatx_fs {
@@ -107,7 +119,7 @@ struct fatx_partition_map_entry {
 };
 
 enum fatx_format {
-    FATX_FORMAT_NONE,
+    FATX_FORMAT_INVALID,
     FATX_FORMAT_RETAIL,
     FATX_FORMAT_F_TAKES_ALL
 };
@@ -142,7 +154,6 @@ int fatx_disk_size_remaining(char const *path, size_t offset, size_t *size);
 int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, enum fatx_format format_type, size_t sectors_per_cluster);
 int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, size_t offset, size_t size, size_t sector_size, size_t sectors_per_cluster);
 int fatx_drive_to_offset_size(char drive_letter, size_t *offset, size_t *size);
-int fatx_disk_read_refurb_info(char const *path);
 int fatx_disk_write_refurb_info(char const *path, uint32_t number_of_boots, uint64_t first_power_on);
 
 #endif

--- a/src/fatx.h
+++ b/src/fatx.h
@@ -46,6 +46,8 @@
 #define FATX_RETAIL_CLUSTER_SIZE     (16 * 1024)
 #define FATX_RETAIL_PARTITION_COUNT  5
 
+#define FATX_READ_FROM_SUPERBLOCK    0
+
 struct fatx_fs {
     char const *device_path;
     FILE       *device;

--- a/src/fatx_disk.c
+++ b/src/fatx_disk.c
@@ -19,12 +19,13 @@
 
 #include "fatx_internal.h"
 
-struct fatx_partition_map_entry const fatx_fuse_partition_map[FATX_RETAIL_PARTITION_COUNT] = {
+struct fatx_partition_map_entry const fatx_partition_map[FATX_RETAIL_PARTITION_COUNT] = {
     { .letter = 'x',    .offset = 0x00080000, .size = 0x02ee00000 },
     { .letter = 'y',    .offset = 0x2ee80000, .size = 0x02ee00000 },
     { .letter = 'z',    .offset = 0x5dc80000, .size = 0x02ee00000 },
     { .letter = 'c',    .offset = 0x8ca80000, .size = 0x01f400000 },
     { .letter = 'e',    .offset = 0xabe80000, .size = 0x1312d6000 },
+  //{ .letter = 'f',    .offset = 0x1dd15600, .size = 0x000000000 },
 };
 
 /*
@@ -36,7 +37,7 @@ int fatx_drive_to_offset_size(char drive_letter, size_t *offset, size_t *size)
 
     for (int i = 0; i < FATX_RETAIL_PARTITION_COUNT; i++)
     {
-        pi = &fatx_fuse_partition_map[i];
+        pi = &fatx_partition_map[i];
 
         if (pi->letter == drive_letter)
         {
@@ -62,10 +63,9 @@ int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, e
         return FATX_STATUS_SUCCESS;
     }
 
-    /* Always (re-)format device with retail partitions */
     for (int i = 0; i < FATX_RETAIL_PARTITION_COUNT; i++)
     {
-        pi = &fatx_fuse_partition_map[i];
+        pi = &fatx_partition_map[i];
 
         fatx_info(fs, "-------------------------------------------\n");
         fatx_info(fs, "Formatting partition %u (%c drive) ...\n", i, pi->letter);
@@ -78,22 +78,18 @@ int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, e
          * configure the cluster size on retail partitions or many games
          * will not load. Adjusting sector sizes, however, is okay.
          */
-
         if (fatx_disk_format_partition(fs, path, pi->offset, pi->size, sector_size, FATX_RETAIL_CLUSTER_SIZE / sector_size))
         {
             fatx_error(fs, " - failed to format partition %d\n", i);
             return FATX_STATUS_ERROR;
         }
-
     }
 
-    /* Retail formatting already complete, nothing else to do */
     if (format_type == FATX_FORMAT_RETAIL)
     {
         return FATX_STATUS_SUCCESS;
     }
 
-    /* Format F partition, in addition to retail partitions */
     else if (format_type == FATX_FORMAT_F_TAKES_ALL)
     {
         fatx_info(fs, "-------------------------------------------\n");
@@ -124,21 +120,18 @@ int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, uint64_t of
         return FATX_STATUS_ERROR;
     }
 
-    /* Overwrite the partition superblock with default values */
     if (fatx_write_superblock(fs))
     {
         retval = FATX_STATUS_ERROR;
         goto cleanup;
     }
 
-    /* Overwrite the partition FAT */
     if (fatx_init_fat(fs))
     {
         retval = FATX_STATUS_ERROR;
         goto cleanup;
     }
 
-    /* Overwrite partition root directory cluster */
     if (fatx_init_root(fs))
     {
         retval = FATX_STATUS_ERROR;

--- a/src/fatx_disk.c
+++ b/src/fatx_disk.c
@@ -1,0 +1,153 @@
+/*
+ * FATX Filesystem Library
+ *
+ * Copyright (C) 2015  Matt Borgerson
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "fatx_internal.h"
+
+struct fatx_partition_map_entry const fatx_fuse_partition_map[FATX_RETAIL_PARTITION_COUNT] = {
+    { .letter = 'x',    .offset = 0x00080000, .size = 0x02ee00000 },
+    { .letter = 'y',    .offset = 0x2ee80000, .size = 0x02ee00000 },
+    { .letter = 'z',    .offset = 0x5dc80000, .size = 0x02ee00000 },
+    { .letter = 'c',    .offset = 0x8ca80000, .size = 0x01f400000 },
+    { .letter = 'e',    .offset = 0xabe80000, .size = 0x1312d6000 },
+};
+
+/*
+ * Given a drive letter, determine partition offset and size (in bytes).
+ */
+int fatx_drive_to_offset_size(char drive_letter, size_t *offset, size_t *size)
+{
+    struct fatx_partition_map_entry const *pi;
+
+    for (int i = 0; i < FATX_RETAIL_PARTITION_COUNT; i++)
+    {
+        pi = &fatx_fuse_partition_map[i];
+
+        if (pi->letter == drive_letter)
+        {
+            *offset = pi->offset;
+            *size   = pi->size;
+            return FATX_STATUS_SUCCESS;
+        }
+    }
+
+    return FATX_STATUS_ERROR;
+}
+
+/*
+ * Reformat a disk as FATX.
+ */
+int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, enum fatx_format format_type, size_t sectors_per_cluster)
+{
+    struct fatx_partition_map_entry const *pi;
+    uint64_t f_offset, f_size, disk_size;
+
+    if (format_type == FATX_FORMAT_NONE)
+    {
+        return FATX_STATUS_SUCCESS;
+    }
+
+    /* Always (re-)format device with retail partitions */
+    for (int i = 0; i < FATX_RETAIL_PARTITION_COUNT; i++)
+    {
+        pi = &fatx_fuse_partition_map[i];
+
+        fatx_info(fs, "-------------------------------------------\n");
+        fatx_info(fs, "Formatting partition %u (%c drive) ...\n", i, pi->letter);
+
+        /*
+         * Xapi initialization validates that the cluster size of retail
+         * partitions is 16kb when a game begins loading.
+         *
+         * For this reason, it is imperative that we do not let users
+         * configure the cluster size on retail partitions or many games
+         * will not load. Adjusting sector sizes, however, is okay.
+         */
+
+        if (fatx_disk_format_partition(fs, path, pi->offset, pi->size, sector_size, FATX_RETAIL_CLUSTER_SIZE / sector_size))
+        {
+            fatx_error(fs, " - failed to format partition %d\n", i);
+            return FATX_STATUS_ERROR;
+        }
+
+    }
+
+    /* Retail formatting already complete, nothing else to do */
+    if (format_type == FATX_FORMAT_RETAIL)
+    {
+        return FATX_STATUS_SUCCESS;
+    }
+
+    /* Format F partition, in addition to retail partitions */
+    else if (format_type == FATX_FORMAT_F_TAKES_ALL)
+    {
+        fatx_info(fs, "-------------------------------------------\n");
+        fatx_info(fs, "Formatting partition %u (%c drive) ...\n", 6, 'f');
+
+        f_offset = pi->offset + pi->size;
+        if (fatx_disk_size(path, &disk_size))
+        {
+            fatx_error(fs, " - failed to get disk size\n");
+            return FATX_STATUS_ERROR;
+        }
+        f_size = disk_size - f_offset;
+        fatx_disk_format_partition(fs, path, f_offset, f_size, sector_size, sectors_per_cluster);
+    }
+
+    return FATX_STATUS_SUCCESS;
+}
+
+/*
+ * Format partition.
+ */
+int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster)
+{
+    int retval;
+
+    if (fatx_open_device(fs, path, offset, size, sector_size, sectors_per_cluster))
+    {
+        return FATX_STATUS_ERROR;
+    }
+
+    /* Overwrite the partition superblock with default values */
+    if (fatx_write_superblock(fs))
+    {
+        retval = FATX_STATUS_ERROR;
+        goto cleanup;
+    }
+
+    /* Overwrite the partition FAT */
+    if (fatx_init_fat(fs))
+    {
+        retval = FATX_STATUS_ERROR;
+        goto cleanup;
+    }
+
+    /* Overwrite partition root directory cluster */
+    if (fatx_init_root(fs))
+    {
+        retval = FATX_STATUS_ERROR;
+        goto cleanup;
+    }
+
+    retval = FATX_STATUS_SUCCESS;
+
+cleanup:
+    fatx_close_device(fs);
+    return retval;
+}

--- a/src/fatx_fat.c
+++ b/src/fatx_fat.c
@@ -61,16 +61,15 @@ int fatx_init_fat(struct fatx_fs *fs)
     while (bytes_remaining > 0)
     {
         size_t bytes_to_write = MIN(chunk_size, bytes_remaining);
-        if(fatx_dev_write(fs, chunk, bytes_to_write, 1) != 1)
+        if (fatx_dev_write(fs, chunk, bytes_to_write, 1) != 1)
         {
             fatx_error(fs, "failed to clear FAT chunk (offset 0x%zx)\n", fs->fat_offset + (bytes_remaining - fs->fat_size));
             retval = FATX_STATUS_ERROR;
-            goto cleanup;
+            break;
         }
         bytes_remaining -= bytes_to_write;
     }
 
-cleanup:
     free(chunk);
     return retval;
 }
@@ -199,6 +198,8 @@ int fatx_get_fat_entry_type(struct fatx_fs *fs, fatx_fat_entry entry)
     {
         case 0x00000000:
             return FATX_CLUSTER_AVAILABLE;
+        case 0xfffffff0:
+            return FATX_CLUSTER_RESERVED;
         case 0xfffffff7:
             return FATX_CLUSTER_BAD;
         case 0xfffffff8:
@@ -207,7 +208,7 @@ int fatx_get_fat_entry_type(struct fatx_fs *fs, fatx_fat_entry entry)
             return FATX_CLUSTER_END;
     }
 
-    if (entry <= 0xfffffff0)
+    if (entry < 0xfffffff0)
     {
         return FATX_CLUSTER_DATA;
     }

--- a/src/fatx_internal.h
+++ b/src/fatx_internal.h
@@ -22,14 +22,8 @@
 
 #include "fatx.h"
 
-/* Offset of the filesystem signature, in bytes. */
-#define FATX_SIGNATURE_OFFSET        0
-
 /* FATX filesystem signature ('FATX') */
 #define FATX_SIGNATURE               0x58544146
-
-/* Offset of the superblock, in bytes. */
-#define FATX_SUPERBLOCK_OFFSET       4
 
 /* Size of the superblock, in bytes. */
 #define FATX_SUPERBLOCK_SIZE         4096
@@ -46,7 +40,7 @@
 
 /* Mask to be applied when reading FAT entry values. */
 #define FATX_FAT16_ENTRY_MASK        0x0000ffff
-#define FATX_FAT32_ENTRY_MASK        0x0fffffff
+#define FATX_FAT32_ENTRY_MASK        0xffffffff
 
 /* Markers used in the filename_size field of the directory entry. */
 #define FATX_DELETED_FILE_MARKER     0xe5
@@ -88,10 +82,12 @@
  */
 #pragma pack(1)
 struct fatx_superblock {
+    uint32_t signature;
     uint32_t volume_id;
     uint32_t sectors_per_cluster;
-    uint16_t root_cluster;
-    uint32_t unknown1;
+    uint32_t root_cluster;
+    uint16_t unknown1;
+    uint8_t  padding[4078];
 };
 #pragma pack()
 
@@ -118,7 +114,9 @@ typedef uint32_t fatx_fat_entry;
 
 /* Partition Functions */
 int fatx_check_partition_signature(struct fatx_fs *fs);
-int fatx_process_superblock(struct fatx_fs *fs);
+int fatx_init_superblock(struct fatx_fs *fs, size_t sectors_per_cluster);
+int fatx_read_superblock(struct fatx_fs *fs);
+int fatx_write_superblock(struct fatx_fs *fs);
 
 /* Device Functions */
 int fatx_dev_seek(struct fatx_fs *fs, off_t offset);
@@ -127,6 +125,8 @@ size_t fatx_dev_read(struct fatx_fs *fs, void *buf, size_t size, size_t items);
 size_t fatx_dev_write(struct fatx_fs *fs, const void *buf, size_t size, size_t items);
 
 /* FAT Functions */
+int fatx_init_fat(struct fatx_fs *fs);
+int fatx_init_root(struct fatx_fs *fs);
 int fatx_read_fat(struct fatx_fs *fs, size_t index, fatx_fat_entry *entry);
 int fatx_write_fat(struct fatx_fs *fs, size_t index, fatx_fat_entry entry);
 int fatx_cluster_number_to_byte_offset(struct fatx_fs *fs, size_t cluster, size_t *offset);

--- a/src/fatx_internal.h
+++ b/src/fatx_internal.h
@@ -70,15 +70,18 @@
 
 /* FAT entry types (not the actual value of the entry). */
 #define FATX_CLUSTER_AVAILABLE       0
-#define FATX_CLUSTER_MEDIA           1
-#define FATX_CLUSTER_DATA            2
+#define FATX_CLUSTER_DATA            1
+#define FATX_CLUSTER_RESERVED        2
 #define FATX_CLUSTER_BAD             3
-#define FATX_CLUSTER_END             4
-#define FATX_CLUSTER_INVALID         5
+#define FATX_CLUSTER_MEDIA           4
+#define FATX_CLUSTER_END             5
+#define FATX_CLUSTER_INVALID         6
 
 /* Helpful macros. */
 #define MIN(a,b) ( ( (a) <= (b) ) ? (a) : (b) )
 #define MAX(a,b) ( ( (a) >= (b) ) ? (a) : (b) )
+#define ARRAY_SIZE(array) \
+    (sizeof(array) / sizeof(array[0]))
 
 /*
  * The refurb info as it appears on disk.

--- a/src/fatx_internal.h
+++ b/src/fatx_internal.h
@@ -22,6 +22,12 @@
 
 #include "fatx.h"
 
+/* FATX refurb info signature ('RFRB') */
+#define FATX_REFURB_SIGNATURE        0x42524652
+
+/* Offset of the refurb info on the physical disk */
+#define FATX_REFURB_OFFSET           0x600
+
 /* FATX filesystem signature ('FATX') */
 #define FATX_SIGNATURE               0x58544146
 
@@ -75,7 +81,18 @@
 #define MAX(a,b) ( ( (a) >= (b) ) ? (a) : (b) )
 
 /*
- * The superblock, as it appears on disk.
+ * The refurb info as it appears on disk.
+ */
+#pragma pack(1)
+struct fatx_refurb_info {
+    uint32_t signature;
+    uint32_t number_of_boots;
+    uint64_t first_power_on;
+};
+#pragma pack()
+
+/*
+ * The FATX superblock as it appears on disk.
  */
 #pragma pack(1)
 struct fatx_superblock {

--- a/src/fatx_internal.h
+++ b/src/fatx_internal.h
@@ -68,7 +68,7 @@
 
 /* FAT entry types (not the actual value of the entry). */
 #define FATX_CLUSTER_AVAILABLE       0
-#define FATX_CLUSTER_RESERVED        1
+#define FATX_CLUSTER_MEDIA           1
 #define FATX_CLUSTER_DATA            2
 #define FATX_CLUSTER_BAD             3
 #define FATX_CLUSTER_END             4

--- a/src/fatx_internal.h
+++ b/src/fatx_internal.h
@@ -38,10 +38,6 @@
 /* Number of reserved entries in the FAT. */
 #define FATX_FAT_RESERVED_ENTRIES_COUNT 1
 
-/* Mask to be applied when reading FAT entry values. */
-#define FATX_FAT16_ENTRY_MASK        0x0000ffff
-#define FATX_FAT32_ENTRY_MASK        0xffffffff
-
 /* Markers used in the filename_size field of the directory entry. */
 #define FATX_DELETED_FILE_MARKER     0xe5
 #define FATX_END_OF_DIR_MARKER       0xff
@@ -76,6 +72,7 @@
 
 /* Helpful macros. */
 #define MIN(a,b) ( ( (a) <= (b) ) ? (a) : (b) )
+#define MAX(a,b) ( ( (a) >= (b) ) ? (a) : (b) )
 
 /*
  * The superblock, as it appears on disk.
@@ -90,6 +87,7 @@ struct fatx_superblock {
     uint8_t  padding[4078];
 };
 #pragma pack()
+_Static_assert(sizeof(struct fatx_superblock) == 4096, "fatx_superblock struct *must* be 4096 bytes");
 
 /*
  * The directory entry as it appears on disk.

--- a/src/fatx_partition.c
+++ b/src/fatx_partition.c
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sys/time.h>
 #include "fatx_internal.h"
 
 /*
@@ -27,7 +28,7 @@ int fatx_check_partition_signature(struct fatx_fs *fs)
     uint32_t signature;
     size_t   read;
 
-    if (fatx_dev_seek(fs, fs->partition_offset+FATX_SIGNATURE_OFFSET))
+    if (fatx_dev_seek(fs, fs->partition_offset))
     {
         fatx_error(fs, "failed to seek to signature\n");
         return -1;
@@ -51,14 +52,29 @@ int fatx_check_partition_signature(struct fatx_fs *fs)
 }
 
 /*
+ * Initialize the partition with a new superblock.
+ */
+int fatx_init_superblock(struct fatx_fs *fs, size_t sectors_per_cluster)
+{
+    struct timeval time;
+
+    gettimeofday(&time, NULL);
+    fs->volume_id = time.tv_usec;
+    fs->root_cluster = 1;
+    fs->sectors_per_cluster = sectors_per_cluster;
+
+    return FATX_STATUS_SUCCESS;
+}
+
+/*
  * Process the partition superblock.
  */
-int fatx_process_superblock(struct fatx_fs *fs)
+int fatx_read_superblock(struct fatx_fs *fs)
 {
     struct fatx_superblock superblock;
     size_t read;
 
-    if (fatx_dev_seek(fs, fs->partition_offset+FATX_SUPERBLOCK_OFFSET))
+    if (fatx_dev_seek(fs, fs->partition_offset))
     {
         fatx_error(fs, "failed to seek to superblock\n");
         return -1;
@@ -71,9 +87,45 @@ int fatx_process_superblock(struct fatx_fs *fs)
         return -1;
     }
 
+    if (superblock.signature != FATX_SIGNATURE)
+    {
+        fatx_error(fs, "invalid signature\n");
+        return -1;
+    }
+
     fs->volume_id = superblock.volume_id;
     fs->sectors_per_cluster = superblock.sectors_per_cluster;
     fs->root_cluster = superblock.root_cluster;
+
+    return FATX_STATUS_SUCCESS;
+}
+
+/*
+ * Write the partition superblock.
+ */
+int fatx_write_superblock(struct fatx_fs *fs)
+{
+    struct fatx_superblock superblock;
+
+    if (fatx_dev_seek(fs, fs->partition_offset))
+    {
+        fatx_error(fs, "failed to seek to superblock\n");
+        return FATX_STATUS_ERROR;
+    }
+
+    memset(&superblock, 0xFF, sizeof(struct fatx_superblock));
+
+    superblock.signature = FATX_SIGNATURE;
+    superblock.sectors_per_cluster = fs->sectors_per_cluster;
+    superblock.volume_id = fs->volume_id;
+    superblock.root_cluster = fs->root_cluster;
+    superblock.unknown1 = 0;
+
+    if (fatx_dev_write(fs, &superblock, sizeof(struct fatx_superblock), 1) != 1)
+    {
+        fatx_error(fs, "failed to write superblock\n");
+        return FATX_STATUS_ERROR;
+    }
 
     return FATX_STATUS_SUCCESS;
 }

--- a/src/fatxfs_fuse.c
+++ b/src/fatxfs_fuse.c
@@ -773,7 +773,7 @@ int main(int argc, char *argv[])
                               pd.mount_partition_offset,
                               pd.mount_partition_size,
                               pd.device_sector_size,
-                              0);
+                              FATX_READ_FROM_SUPERBLOCK);
     if (status)
     {
         fprintf(stderr, "failed to initialize the filesystem\n");

--- a/src/fatxfs_fuse.c
+++ b/src/fatxfs_fuse.c
@@ -40,38 +40,26 @@ enum {
     FATX_FUSE_OPT_KEY_OFFSET,
     FATX_FUSE_OPT_KEY_SIZE,
     FATX_FUSE_OPT_KEY_SECTOR_SIZE,
+    FATX_FUSE_OPT_KEY_SECTORS_PER_CLUSTER,
+    FATX_FUSE_OPT_KEY_FORMAT,
+    FATX_FUSE_OPT_KEY_DESTROY_DATA,
     FATX_FUSE_OPT_KEY_LOG,
     FATX_FUSE_OPT_KEY_LOGLEVEL,
 };
 
-/*
- * Xbox Harddisk Partition Map
- */
-struct fatx_fuse_partition_map_entry {
-    char   letter;
-    size_t offset;
-    size_t size;
-};
-
-struct fatx_fuse_partition_map_entry const fatx_fuse_partition_map[] = {
-    { .letter = 'x',    .offset = 0x00080000, .size = 0x02ee00000 },
-    { .letter = 'y',    .offset = 0x2ee80000, .size = 0x02ee00000 },
-    { .letter = 'z',    .offset = 0x5dc80000, .size = 0x02ee00000 },
-    { .letter = 'c',    .offset = 0x8ca80000, .size = 0x01f400000 },
-    { .letter = 'e',    .offset = 0xabe80000, .size = 0x131f00000 },
-    { .letter = '\x00', .offset = 0x00000000, .size = 0x000000000 },
-};
-
 struct fatx_fuse_private_data {
-    struct fatx_fs *fs;
-    char const     *device_path;
-    char const     *log_path;
-    char            mount_partition_drive;
-    size_t          mount_partition_offset;
-    size_t          mount_partition_size;
-    size_t          device_sector_size;
-    FILE           *log_handle;
-    int             log_level;
+    struct fatx_fs   *fs;
+    char const       *device_path;
+    char const       *log_path;
+    char              mount_partition_drive;
+    size_t            mount_partition_offset;
+    size_t            mount_partition_size;
+    size_t            device_sector_size;
+    size_t            device_sectors_per_cluster;
+    FILE             *log_handle;
+    int               log_level;
+    enum fatx_format  format;
+    int               format_confirm;
 };
 
 /*
@@ -102,7 +90,6 @@ int fatx_fuse_opt_proc(void *data, const char *arg, int key, struct fuse_args *o
  * Helper functions.
  */
 struct fatx_fuse_private_data *fatx_fuse_get_private_data(void);
-int fatx_fuse_drive_to_offset_size(char drive_letter, size_t *offset, size_t *size);
 void fatx_fuse_print_usage(void);
 void fatx_fuse_print_version(void);
 
@@ -133,26 +120,6 @@ struct fatx_fuse_private_data *fatx_fuse_get_private_data(void)
     context = fuse_get_context();
     if (context == NULL) return NULL;
     return (struct fatx_fuse_private_data *)(context->private_data);
-}
-
-/*
- * Given a drive letter, determine partition offset and size (in bytes).
- */
-int fatx_fuse_drive_to_offset_size(char drive_letter, size_t *offset, size_t *size)
-{
-    struct fatx_fuse_partition_map_entry const *pi;
-
-    for (pi = &fatx_fuse_partition_map[0]; pi->letter != '\x00'; pi++)
-    {
-        if (pi->letter == drive_letter)
-        {
-            *offset = pi->offset;
-            *size   = pi->size;
-            return 0;
-        }
-    }
-
-    return -1;
 }
 
 /*
@@ -578,6 +545,32 @@ int fatx_fuse_opt_proc(void *data, const char *arg, int key, struct fuse_args *o
         pd->device_sector_size = strtol(arg, NULL, 0);
         return 0;
 
+    case FATX_FUSE_OPT_KEY_SECTORS_PER_CLUSTER:
+        arg = fatx_fuse_opt_consume_key(arg);
+        pd->device_sectors_per_cluster = strtol(arg, NULL, 0);
+        return 0;
+
+    case FATX_FUSE_OPT_KEY_FORMAT:
+        arg = fatx_fuse_opt_consume_key(arg);
+        if (!strcmp(arg, "retail"))
+        {
+            pd->format = FATX_FORMAT_RETAIL;
+        }
+        else if (!strcmp(arg, "f-takes-all"))
+        {
+            pd->format = FATX_FORMAT_F_TAKES_ALL;
+        }
+        else
+        {
+            fprintf(stderr, "invalid format '%s' specified\n", arg);
+            return -1;
+        }
+        return 0;
+
+    case FATX_FUSE_OPT_KEY_DESTROY_DATA:
+        pd->format_confirm = 1;
+        return 0;
+
     case FATX_FUSE_OPT_KEY_LOG:
         pd->log_path = fatx_fuse_opt_consume_key(arg);
         return 0;
@@ -619,17 +612,22 @@ void fatx_fuse_print_usage(void)
     fprintf(stderr, "Usage: %s <device> <mountpoint> [<options>]\n", prog_short_name);
     fprintf(stderr, "   or: %s <device> <mountpoint> --drive=c|e|x|y|z [<options>]\n", prog_short_name);
     fprintf(stderr, "   or: %s <device> <mountpoint> --offset=<offset> --size=<size> [<options>]\n\n", prog_short_name);
-    fprintf(stderr, "General Options:\n"
-                    "    -o opt, [opt...]       mount options\n"
-                    "    -h --help              print help\n"
-                    "    -V --version           print version\n\n"
+    fprintf(stderr, "General options:\n"
+                    "    -o opt, [opt...]               mount options\n"
+                    "    -h --help                      print help\n"
+                    "    -V --version                   print version\n\n"
                     "FATXFS options:\n"
-                    "    --drive=<letter>       mount a partition by its drive letter\n"
-                    "    --offset=<offset>      specify the offset (in bytes) of a partition manually\n"
-                    "    --size=<size>          specify the size (in bytes) of a partition manually\n"
-                    "    --sector-size=<size>   specify the size (in bytes) of a device sector (default is 512)\n"
-                    "    --log=<log path>       enable fatxfs logging\n"
-                    "    --loglevel=<level>     control the log output level (a higher value yields more output)\n\n");
+                    "    --drive=<letter>               mount a partition by its drive letter\n"
+                    "    --offset=<offset>              specify the offset (in bytes) of a partition manually\n"
+                    "    --size=<size>                  specify the size (in bytes) of a partition manually\n"
+                    "    --sector-size=<size>           specify the size (in bytes) of a device sector (default is 512)\n"
+                    "    --log=<log path>               enable fatxfs logging\n"
+                    "    --loglevel=<level>             control the log output level (a higher value yields more output)\n\n"
+                    "Disk formatting options:\n"
+                    "    --format=<format>              specify the format (retail, f-takes-all) to initialize the device to\n"
+                    "    --sector-size=<size>           specify the size (in bytes) of a device sector (default is 512)\n"
+                    "    --sectors-per-cluster=<size>   specify the sectors per cluster when initializing non-retail partitions (default is 128)\n"
+                    "    --destroy-all-existing-data    acknowledge that device formatting will destroy all existing data\n\n");
 
     /* Print FUSE options */
     argv[0] = prog_short_name;
@@ -650,25 +648,29 @@ int main(int argc, char *argv[])
 
     /* Define command line options. */
     struct fuse_opt const opts [] = {
-        FUSE_OPT_KEY("-h",             FATX_FUSE_OPT_KEY_HELP),
-        FUSE_OPT_KEY("--help",         FATX_FUSE_OPT_KEY_HELP),
-        FUSE_OPT_KEY("-V",             FATX_FUSE_OPT_KEY_VERSION),
-        FUSE_OPT_KEY("--version",      FATX_FUSE_OPT_KEY_VERSION),
-        FUSE_OPT_KEY("--drive=",       FATX_FUSE_OPT_KEY_DRIVE),
-        FUSE_OPT_KEY("--offset=",      FATX_FUSE_OPT_KEY_OFFSET),
-        FUSE_OPT_KEY("--size=",        FATX_FUSE_OPT_KEY_SIZE),
-        FUSE_OPT_KEY("--sector-size=", FATX_FUSE_OPT_KEY_SECTOR_SIZE),
-        FUSE_OPT_KEY("--log=",         FATX_FUSE_OPT_KEY_LOG),
-        FUSE_OPT_KEY("--loglevel=",    FATX_FUSE_OPT_KEY_LOGLEVEL),
+        FUSE_OPT_KEY("-h",                           FATX_FUSE_OPT_KEY_HELP),
+        FUSE_OPT_KEY("--help",                       FATX_FUSE_OPT_KEY_HELP),
+        FUSE_OPT_KEY("-V",                           FATX_FUSE_OPT_KEY_VERSION),
+        FUSE_OPT_KEY("--version",                    FATX_FUSE_OPT_KEY_VERSION),
+        FUSE_OPT_KEY("--drive=",                     FATX_FUSE_OPT_KEY_DRIVE),
+        FUSE_OPT_KEY("--offset=",                    FATX_FUSE_OPT_KEY_OFFSET),
+        FUSE_OPT_KEY("--size=",                      FATX_FUSE_OPT_KEY_SIZE),
+        FUSE_OPT_KEY("--sector-size=",               FATX_FUSE_OPT_KEY_SECTOR_SIZE),
+        FUSE_OPT_KEY("--format=" ,                   FATX_FUSE_OPT_KEY_FORMAT),
+        FUSE_OPT_KEY("--sectors-per-cluster=" ,      FATX_FUSE_OPT_KEY_SECTORS_PER_CLUSTER),
+        FUSE_OPT_KEY("--destroy-all-existing-data",  FATX_FUSE_OPT_KEY_DESTROY_DATA),
+        FUSE_OPT_KEY("--log=",                       FATX_FUSE_OPT_KEY_LOG),
+        FUSE_OPT_KEY("--loglevel=",                  FATX_FUSE_OPT_KEY_LOGLEVEL),
         FUSE_OPT_END,
     };
 
     /* Initialize private data. */
     memset(&pd, 0, sizeof(struct fatx_fuse_private_data));
-    pd.mount_partition_size   = -1;
-    pd.mount_partition_offset = -1;
-    pd.device_sector_size     = 512;
-    pd.log_level              = FATX_LOG_LEVEL_INFO;
+    pd.mount_partition_size       = -1;
+    pd.mount_partition_offset     = -1;
+    pd.device_sector_size         = 512;
+    pd.device_sectors_per_cluster = 128;
+    pd.log_level                  = FATX_LOG_LEVEL_INFO;
 
     /* Parse command line arguments. */
     if (fuse_opt_parse(&args, &pd, opts, &fatx_fuse_opt_proc) != 0)
@@ -713,9 +715,9 @@ int main(int argc, char *argv[])
             pd.mount_partition_drive = 'c';
         }
 
-        status = fatx_fuse_drive_to_offset_size(pd.mount_partition_drive,
-                                                &pd.mount_partition_offset,
-                                                &pd.mount_partition_size);
+        status = fatx_drive_to_offset_size(pd.mount_partition_drive,
+                                           &pd.mount_partition_offset,
+                                           &pd.mount_partition_size);
         if (status)
         {
             fprintf(stderr, "unknown drive letter '%c'\n", pd.mount_partition_drive);
@@ -746,12 +748,32 @@ int main(int argc, char *argv[])
         fatx_log_init(pd.fs, pd.log_handle, pd.log_level);
     }
 
+    /* Reformat the drive (if desired) */
+    if (pd.format)
+    {
+        if (pd.format_confirm)
+        {
+            return fatx_disk_format(pd.fs, pd.device_path, pd.device_sector_size, pd.format, pd.device_sectors_per_cluster);
+        }
+        else
+        {
+            fprintf(stderr, "please specify --destroy-all-existing-data to perform device formatting\n");
+            return -1;
+        }
+    }
+    else if (pd.format_confirm)
+    {
+        fprintf(stderr, "--destroy-all-existing-data can only be used with --format\n");
+        return -1;
+    }
+
     /* Open the device */
     status = fatx_open_device(pd.fs,
                               pd.device_path,
                               pd.mount_partition_offset,
                               pd.mount_partition_size,
-                              pd.device_sector_size);
+                              pd.device_sector_size,
+                              0);
     if (status)
     {
         fprintf(stderr, "failed to initialize the filesystem\n");

--- a/src/fatxfs_fuse.c
+++ b/src/fatxfs_fuse.c
@@ -610,7 +610,7 @@ void fatx_fuse_print_usage(void)
     /* Print basic usage */
     fprintf(stderr, "FATXFS - Userspace FATX Filesystem Driver\n\n");
     fprintf(stderr, "Usage: %s <device> <mountpoint> [<options>]\n", prog_short_name);
-    fprintf(stderr, "   or: %s <device> <mountpoint> --drive=c|e|x|y|z [<options>]\n", prog_short_name);
+    fprintf(stderr, "   or: %s <device> <mountpoint> --drive=c|e|x|y|z|f [<options>]\n", prog_short_name);
     fprintf(stderr, "   or: %s <device> <mountpoint> --offset=<offset> --size=<size> [<options>]\n\n", prog_short_name);
     fprintf(stderr, "General options:\n"
                     "    -o opt, [opt...]               mount options\n"

--- a/src/fatxfs_fuse.c
+++ b/src/fatxfs_fuse.c
@@ -625,7 +625,6 @@ void fatx_fuse_print_usage(void)
                     "    --loglevel=<level>             control the log output level (a higher value yields more output)\n\n"
                     "Disk formatting options:\n"
                     "    --format=<format>              specify the format (retail, f-takes-all) to initialize the device to\n"
-                    "    --sector-size=<size>           specify the size (in bytes) of a device sector (default is 512)\n"
                     "    --sectors-per-cluster=<size>   specify the sectors per cluster when initializing non-retail partitions (default is 128)\n"
                     "    --destroy-all-existing-data    acknowledge that device formatting will destroy all existing data\n\n");
 


### PR DESCRIPTION
I wrote these additions today and am making this PR as near-complete. It will help address #18 and #30. I also don't really want to be developing on a moving target so I'd rather get discussion and feedback going now :-P

This PR will add the following flags:

```
Disk formatting options:
    --format=<format>              specify the format (retail, f-takes-all) to initialize the device to
    --sector-size=<size>           specify the size (in bytes) of a device sector (default is 512)
    --sectors-per-cluster=<size>   specify the sectors per cluster when initializing non-retail partitions (default is 128)
    --destroy-all-existing-data    acknowledge that device formatting will destroy all existing data
```

Example usage:

```
fatxfs /dev/sdb --format=retail --destroy-all-existing-data
```

Disk formatting should be identical to hardware. 

~~However, tip/master of the main FATX repo appears to have regressed something since 44a03f82b18f4a49a6a4b02361cc469718e7af76 and I rebased onto it without checking, whoops. I can't seem to write a file above a few KB to a 4096 byte sector drive anymore. Previously I was able to, and these files worked on both on Hardware and in XEMU.~~

There are a few other fixes that ended up in here. Since code is currently churning on this repo, I hope you don't mind them getting lumped into this. I'll try to leave comments on a few points of the PR that might need to be discussed further.

Please feel free to make any changes.

EDIT: By 'near-complete' I mean I haven't been able to fully test the end-to-end workflow of initializing a disk, writing a file into it, and loading it on XEMU/HW with master regressed. Also I imagine there might be some questions/changes/cleanup that may be requested 👍 