### PR TITLE
pyfatx: Expose file write functions

### DIFF
--- a/pyfatx/__init__.py
+++ b/pyfatx/__init__.py
@@ -3,7 +3,7 @@ import os
 import platform
 import subprocess
 import logging
-from typing import Optional, Generator, Tuple, Sequence
+from typing import AnyStr, Generator, Optional, Sequence, Tuple
 
 from .libfatx import ffi
 from .libfatx.lib import *
@@ -93,7 +93,7 @@ class Fatx:
 		fname = ffi.string(in_attr.filename).decode('ascii')
 		return FatxAttr(fname, in_attr.attributes, in_attr.file_size)
 
-	def get_attr(self, path: str) -> FatxAttr:
+	def get_attr(self, path: AnyStr) -> FatxAttr:
 		"""
 		Get file attributes for a given path.
 		"""
@@ -157,6 +157,80 @@ class Fatx:
 		s = fatx_read(self.fs, path, offset, size, buf)
 		assert s == size
 		return ffi.buffer(buf)
+
+	def create_dirent(self, path: AnyStr, attributes: int = 0):
+		"""
+		Creates an empty file.
+		"""
+		dir_name = self._sanitize_path(os.path.dirname(path))
+		assert dir_name
+
+		d = ffi.new('struct fatx_dir *')
+		s = fatx_open_dir(self.fs, dir_name, d)
+		assert s == 0
+
+		path = self._sanitize_path(path)
+		s = fatx_create_dirent(self.fs, path, d, attributes)
+		if s:
+			fatx_close_dir(self.fs, d)
+			assert s == 0
+
+		s = fatx_close_dir(self.fs, d)
+		assert s == 0
+
+	def write(self, path: str, content: bytes, offset: int = 0, new_file_attributes: int = 0):
+		"""
+		Write to a file.
+		"""
+		path = self._sanitize_path(path)
+		try:
+			attr = self.get_attr(path)
+		except AssertionError:
+			self.create_dirent(path, new_file_attributes)
+			attr = self.get_attr(path)
+
+		if attr.is_file:
+			assert not attr.is_readonly
+		else:
+			assert not attr.is_directory
+
+		s = fatx_write(self.fs, path, offset, len(content), content)
+		assert s == len(content)
+
+	def rename(self, current_name: str, new_name: str):
+		"""
+		Rename an existing file.
+
+		`current_name` must exist and be a file.
+		`new_name` must be a valid filename and must be in the same directory as
+		`current_name`.
+		"""
+		from_path = self._sanitize_path(current_name)
+		attr = self.get_attr(from_path)
+		# Only files are currently supported by libfatx.
+		assert attr.is_file
+
+		to_path = self._sanitize_path(new_name)
+		s = fatx_rename(self.fs, from_path, to_path)
+		assert s == 0
+
+	def truncate(self, path: AnyStr, new_size: int):
+		"""
+		Truncate an existing file to the given size.
+		"""
+		path = self._sanitize_path(path)
+		attr = self.get_attr(path)
+		assert attr.is_file
+		s = fatx_truncate(self.fs, path, new_size)
+		assert s == 0
+
+	def unlink(self, path: AnyStr):
+		"""
+		Delete an existing file.
+		"""
+		path = self._sanitize_path(path)
+		s = fatx_unlink(self.fs, path)
+		assert s == 0
 
 	@classmethod
 	def format(cls, path:str):

--- a/tests/test.py
+++ b/tests/test.py
@@ -17,6 +17,56 @@ class BasicTest(unittest.TestCase):
 		m.update(d)
 		assert m.hexdigest() == '338e6e203d9f1db5f2c1d976b8969af42049c32e1a65ac0347fbc6efcf5bd7c6'
 
+	def test_create_file(self):
+		test_file_path = '/test_file.txt'
+		fs = Fatx('xbox_hdd.img')
+		content = b'12345'
+		fs.write(test_file_path, content)
+
+		written = fs.read(test_file_path)
+		assert written == content
+
+		fs.unlink(test_file_path)
+		file_still_available = False
+		try:
+			fs.get_attr(test_file_path)
+			file_still_available = True
+		except AssertionError:
+			pass
+		assert not file_still_available
+
+	def test_truncate_file(self):
+		test_file_path = '/test_file.txt'
+		fs = Fatx('xbox_hdd.img')
+		content = b'12345'
+		fs.write(test_file_path, content)
+
+		fs.truncate(test_file_path, 3)
+
+		written = fs.read(test_file_path)
+		assert written == content[:3]
+
+		fs.unlink(test_file_path)
+
+	def test_rename_file(self):
+		test_file_path = '/test_file.txt'
+		fs = Fatx('xbox_hdd.img')
+		content = b'12345'
+		fs.write(test_file_path, content)
+
+		new_filename = '/renamed_test_file.txt'
+		fs.rename(test_file_path, new_filename)
+
+		original_file_still_available = False
+		try:
+			fs.get_attr(test_file_path)
+			original_file_still_available = True
+		except AssertionError:
+			pass
+		assert not original_file_still_available
+
+		fs.unlink(new_filename)
+
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Needed for runtime configuration of nxdk_pgraph_tests in xemu-test.