### PR TITLE
libfatx: Zero out clusters when allocating them

### DIFF
--- a/libfatx/fatx_fat.c
+++ b/libfatx/fatx_fat.c
@@ -327,6 +327,7 @@ int fatx_alloc_cluster(struct fatx_fs *fs, size_t *cluster)
     int status;
     fatx_fat_entry fat_entry;
     size_t i;
+    void *zero;
 
     fatx_debug(fs, "fatx_alloc_cluster()\n");
 
@@ -349,6 +350,16 @@ int fatx_alloc_cluster(struct fatx_fs *fs, size_t *cluster)
 
     status = fatx_mark_cluster_end(fs, i);
     if (status != FATX_STATUS_SUCCESS) return status;
+
+    status = fatx_dev_seek_cluster(fs, i, 0);
+    if (status != FATX_STATUS_SUCCESS) return status;
+
+    zero = calloc(1, fs->bytes_per_cluster);
+    if (!zero) return FATX_STATUS_ERROR;
+
+    status = fatx_dev_write(fs, zero, fs->bytes_per_cluster, 1);
+    free(zero);
+    if (status != 1) return status;
 
     *cluster = i;
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -83,5 +83,33 @@ class BasicTest(unittest.TestCase):
 
 		assert d == b
 
+	
+	def test_write_offset(self):
+		test_file_path = '/offsetfile'
+		fs = Fatx('xbox_hdd.img')
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		# Write 1KB of random data
+		b = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file_path, b)
+
+		# Delete the data
+		d = fs.read(test_file_path)
+		fs.unlink(test_file_path)
+		assert d == b
+
+		# Write 512KB of random data at offset 128
+		b = bytes([rng.getrandbits(8) for _ in range(1024 * 512)])
+		fs.write(test_file_path, b, offset=128)
+
+		# Read from offset zero
+		d = fs.read(test_file_path)
+		fs.unlink(test_file_path)
+
+		assert d == bytes([0] * 128) + b
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Cluster allocations may result in clusters being returned that have garbage data in them. We should zero the clusters on allocation so that they are usable by the filesystem.

Resolves #44 