### PR TITLE
libfatx: Use writeback cache for fat entries

### DIFF
--- a/libfatx/fatx.c
+++ b/libfatx/fatx.c
@@ -66,6 +66,8 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint
     fs->partition_offset = offset;
     fs->partition_size   = size;
 
+    memset(&fs->fat_cache, 0, sizeof(fs->fat_cache));
+
     fs->device = fopen(fs->device_path, "r+b");
     if (!fs->device)
     {
@@ -163,6 +165,11 @@ cleanup:
  */
 int fatx_close_device(struct fatx_fs *fs)
 {
+    int status;
+
+    fatx_debug(fs, "fatx_close_device()\n");
+
+    status = fatx_flush_fat_cache(fs);
     fclose(fs->device);
-    return FATX_STATUS_SUCCESS;
+    return status;
 }

--- a/libfatx/fatx.h
+++ b/libfatx/fatx.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -62,24 +63,35 @@ extern "C" {
  */
 #define FATX_READ_FROM_SUPERBLOCK    0
 
+#define FATX_FAT_CACHE_NUM_ENTRIES   512
+
+struct fatx_cache {
+    size_t position;
+    size_t entries;
+    size_t entry_size;
+    bool   dirty;
+    void  *data;
+};
+
 struct fatx_fs {
-    char const *device_path;
-    FILE       *device;
-    size_t      sector_size;
-    uint64_t    partition_offset;
-    uint64_t    partition_size;
-    uint32_t    volume_id;
-    uint64_t    num_sectors;
-    uint32_t    num_clusters;
-    uint32_t    sectors_per_cluster;
-    uint8_t     fat_type;
-    uint64_t    fat_offset;
-    size_t      fat_size;
-    size_t      root_cluster;
-    uint64_t    cluster_offset;
-    size_t      bytes_per_cluster;
-    FILE       *log_handle;
-    int         log_level;
+    char const       *device_path;
+    FILE             *device;
+    size_t            sector_size;
+    uint64_t          partition_offset;
+    uint64_t          partition_size;
+    uint32_t          volume_id;
+    uint64_t          num_sectors;
+    uint32_t          num_clusters;
+    uint32_t          sectors_per_cluster;
+    uint8_t           fat_type;
+    uint64_t          fat_offset;
+    size_t            fat_size;
+    size_t            root_cluster;
+    uint64_t          cluster_offset;
+    size_t            bytes_per_cluster;
+    FILE             *log_handle;
+    int               log_level;
+    struct fatx_cache fat_cache;
 };
 
 struct fatx_dir {

--- a/libfatx/fatx_internal.h
+++ b/libfatx/fatx_internal.h
@@ -146,6 +146,7 @@ size_t fatx_dev_write(struct fatx_fs *fs, const void *buf, size_t size, size_t i
 /* FAT Functions */
 int fatx_init_fat(struct fatx_fs *fs);
 int fatx_init_root(struct fatx_fs *fs);
+int fatx_flush_fat_cache(struct fatx_fs *fs);
 int fatx_read_fat(struct fatx_fs *fs, size_t index, fatx_fat_entry *entry);
 int fatx_write_fat(struct fatx_fs *fs, size_t index, fatx_fat_entry entry);
 int fatx_cluster_number_to_byte_offset(struct fatx_fs *fs, size_t cluster, uint64_t *offset);


### PR DESCRIPTION
Implements a writeback cache for fat entries. This has a significant performance impact across all filesystem operations.

Below are the results of a simple RW benchmark. The drive image used is a clean copy of the extracted `./tests/xbox_hdd.img` image. No arguments were passed to fatxfs besides the image and mount point.

`master` without caching:
```
> dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 103.525 s, 2.6 MB/s
> dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 2.63456 s, 102 MB/s
```

With caching:
```
> dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 13.7842 s, 19.5 MB/s
> dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 0.386977 s, 694 MB/s
```

`master` with `big_writes` FUSE option:
```
> dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 25.6293 s, 10.5 MB/s
> dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 2.66338 s, 101 MB/s
```

Caching with `big_writes` FUSE option:
```
> dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 3.08812 s, 86.9 MB/s
> dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 0.389961 s, 688 MB/s
```