### PR TITLE
libfatx: Reduce cluster zeroing; search fat from last entry

### DIFF
--- a/libfatx/fatx.h
+++ b/libfatx/fatx.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <sys/types.h>
 

--- a/libfatx/fatx_dir.c
+++ b/libfatx/fatx_dir.c
@@ -359,7 +359,7 @@ int fatx_alloc_dir_entry(struct fatx_fs *fs, struct fatx_dir *dir)
     }
 
     /* If all else fails, then allocate a new cluster */
-    status = fatx_alloc_cluster(fs, &new_cluster);
+    status = fatx_alloc_cluster(fs, &new_cluster, true);
     if (status) return status;
 
     status = fatx_attach_cluster(fs, dir->cluster, new_cluster);
@@ -483,7 +483,7 @@ int fatx_create_dirent(struct fatx_fs *fs, char const *path, struct fatx_dir *di
     free(path_basename);
 
     /* Allocate space for the file */
-    status = fatx_alloc_cluster(fs, &cluster);
+    status = fatx_alloc_cluster(fs, &cluster, true);
     if (status) return status;
 
     /* Allocate directory entry for file */

--- a/libfatx/fatx_file.c
+++ b/libfatx/fatx_file.c
@@ -62,7 +62,7 @@ int fatx_find_cluster_for_file_offset_alloc(struct fatx_fs *fs, struct fatx_attr
         {
             fatx_debug(fs, "out of clusters, allocating new one\n");
 
-            status = fatx_alloc_cluster(fs, &alloc_cluster);
+            status = fatx_alloc_cluster(fs, &alloc_cluster, true);
             if (status) return status;
 
             status = fatx_attach_cluster(fs, cluster, alloc_cluster);
@@ -276,8 +276,9 @@ int fatx_write(struct fatx_fs *fs, char const *path, off_t offset, size_t size, 
             {
                 fatx_debug(fs, "EOF, allocating new cluster\n");
 
+                /* If we're going to write to the entire cluster, there's no need to zero it */
                 size_t new_cluster;
-                status = fatx_alloc_cluster(fs, &new_cluster);
+                status = fatx_alloc_cluster(fs, &new_cluster, size - total_bytes_written < fs->bytes_per_cluster);
                 if (status) return status;
 
                 status = fatx_attach_cluster(fs, cluster, new_cluster);
@@ -363,7 +364,7 @@ int fatx_truncate(struct fatx_fs *fs, char const *path, off_t offset)
         {
             /* Out of clusters, alloc more */
             size_t new_cluster;
-            status = fatx_alloc_cluster(fs, &new_cluster);
+            status = fatx_alloc_cluster(fs, &new_cluster, true);
             if (status) return status;
 
             status = fatx_attach_cluster(fs, cluster, new_cluster);

--- a/libfatx/fatx_internal.h
+++ b/libfatx/fatx_internal.h
@@ -154,7 +154,7 @@ int fatx_get_next_cluster(struct fatx_fs *fs, size_t *cluster);
 int fatx_mark_cluster_available(struct fatx_fs *fs, size_t cluster);
 int fatx_mark_cluster_end(struct fatx_fs *fs, size_t cluster);
 int fatx_free_cluster_chain(struct fatx_fs *fs, size_t first_cluster);
-int fatx_alloc_cluster(struct fatx_fs *fs, size_t *cluster);
+int fatx_alloc_cluster(struct fatx_fs *fs, size_t *cluster, bool zero);
 int fatx_attach_cluster(struct fatx_fs *fs, size_t tail, size_t cluster);
 
 /* Directory Functions */


### PR DESCRIPTION
This contains a couple performance improvements for the cluster allocator. Clusters will not be zeroed during write operations where the cluster will be entirely written over. In addition, the position of the cluster allocator index is preserved between allocations, reducing the number of fat entries that are scanned.
The result is a small improvement in write performance. The improvement is more pronounced when combined with #46 and the `big_writes` FUSE option.

Below are the results of a simple RW benchmark. The drive image used is a clean copy of the extracted ./tests/xbox_hdd.img image. No arguments were passed to fatxfs besides the image and mount point.

`master`:
```
> dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 105.229 s, 2.6 MB/s
> dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 2.74904 s, 97.6 MB/s
```

Allocator improvements:
```
dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 90.2296 s, 3.0 MB/s
dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 2.80066 s, 95.8 MB/s
```

Allocator improvements and fat caching from #46 :
```
> dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 11.6968 s, 22.9 MB/s
> dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 0.389697 s, 689 MB/s
```

Allocator improvements, fat caching, and `big_writes` FUSE option:
```
> dd if=/dev/zero of=test bs=64k count=4k conv=fdatasync
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 0.93846 s, 286 MB/s
> dd if=test of=/dev/null bs=64k count=4k               
4096+0 records in
4096+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 0.407671 s, 658 MB/s
```