### PR TITLE
libfatx: Support exchange/no_replace for rename; unlink on overwrite

### DIFF
--- a/build_cffi.py
+++ b/build_cffi.py
@@ -109,7 +109,7 @@ def ffibuilder():
         int fatx_rmdir(struct fatx_fs *fs, char const *path);
         int fatx_mknod(struct fatx_fs *fs, char const *path);
         int fatx_truncate(struct fatx_fs *fs, char const *path, off_t offset);
-        int fatx_rename(struct fatx_fs *fs, char const *from, char const *to);
+        int fatx_rename(struct fatx_fs *fs, char const *from, char const *to, bool exchange, bool no_replace);
         int fatx_disk_size(char const *path, uint64_t *size);
         int fatx_disk_size_remaining(char const *path, uint64_t offset, uint64_t *size);
         int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, enum fatx_format format_type, size_t sectors_per_cluster);

--- a/fatxfs/fatxfs_fuse.c
+++ b/fatxfs/fatxfs_fuse.c
@@ -450,7 +450,7 @@ int fatx_fuse_rename(const char *from, const char *to)
 
     fatx_debug(pd->fs, "fatx_fuse_rename(from=\"%s\", to=\"%s\")\n", from, to);
 
-    status = fatx_rename(pd->fs, from, to);
+    status = fatx_rename(pd->fs, from, to, false, false);
     return (status == FATX_STATUS_SUCCESS ? 0 : -1);
 }
 

--- a/libfatx/fatx.h
+++ b/libfatx/fatx.h
@@ -149,6 +149,7 @@ int fatx_alloc_dir_entry(struct fatx_fs *fs, struct fatx_dir *dir);
 int fatx_close_dir(struct fatx_fs *fs, struct fatx_dir *dir);
 int fatx_get_attr(struct fatx_fs *fs, char const *path, struct fatx_attr *attr);
 int fatx_set_attr(struct fatx_fs *fs, char const *path, struct fatx_attr *attr);
+int fatx_attr_atomic_swap(struct fatx_fs *fs, char const *dir1, char const *base1, char const *dir2, char const *base2);
 int fatx_utime(struct fatx_fs *fs, char const *path, struct fatx_ts ts[2]);
 int fatx_read(struct fatx_fs *fs, char const *path, off_t offset, size_t size, void *buf);
 int fatx_write(struct fatx_fs *fs, char const *path, off_t offset, size_t size, const void *buf);
@@ -158,7 +159,7 @@ int fatx_mkdir(struct fatx_fs *fs, char const *path);
 int fatx_rmdir(struct fatx_fs *fs, char const *path);
 int fatx_mknod(struct fatx_fs *fs, char const *path);
 int fatx_truncate(struct fatx_fs *fs, char const *path, off_t offset);
-int fatx_rename(struct fatx_fs *fs, char const *from, char const *to);
+int fatx_rename(struct fatx_fs *fs, char const *from, char const *to, bool exchange, bool no_replace);
 void fatx_time_t_to_fatx_ts(const time_t in, struct fatx_ts *out);
 time_t fatx_ts_to_time_t(struct fatx_ts *in);
 

--- a/pyfatx/__init__.py
+++ b/pyfatx/__init__.py
@@ -197,7 +197,7 @@ class Fatx:
 		s = fatx_write(self.fs, path, offset, len(content), content)
 		assert s == len(content)
 
-	def rename(self, current_name: str, new_name: str):
+	def rename(self, current_name: str, new_name: str, exchange=False, no_replace=False):
 		"""
 		Rename an existing file.
 
@@ -211,7 +211,7 @@ class Fatx:
 		assert attr.is_file
 
 		to_path = self._sanitize_path(new_name)
-		s = fatx_rename(self.fs, from_path, to_path)
+		s = fatx_rename(self.fs, from_path, to_path, exchange, no_replace)
 		assert s == 0
 
 	def truncate(self, path: AnyStr, new_size: int):
@@ -230,6 +230,22 @@ class Fatx:
 		"""
 		path = self._sanitize_path(path)
 		s = fatx_unlink(self.fs, path)
+		assert s == 0
+
+	def mkdir(self, path: AnyStr):
+		"""
+		Create a directory.
+		"""
+		path = self._sanitize_path(path)
+		s = fatx_mkdir(self.fs, path)
+		assert s == 0
+
+	def rmdir(self, path: AnyStr):
+		"""
+		Remove a directory.
+		"""
+		path = self._sanitize_path(path)
+		s = fatx_rmdir(self.fs, path)
 		assert s == 0
 
 	@classmethod

--- a/tests/test.py
+++ b/tests/test.py
@@ -111,5 +111,306 @@ class BasicTest(unittest.TestCase):
 		assert d == bytes([0] * 128) + b
 
 
+	def test_rename_overwrite(self):
+		test_file1 = '/test_overwrite1'
+		test_file2 = '/test_overwrite2'
+		fs = Fatx('xbox_hdd.img')
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		# file1 should be above file2 in the dirent list
+		# so this tests that overwriting file1 removes it
+		fs.rename(test_file2, test_file1)
+
+		d = fs.read(test_file1)
+		fs.unlink(test_file1)
+
+		original_file_still_available = False
+		try:
+			fs.get_attr(test_file2)
+			original_file_still_available = True
+		except AssertionError:
+			pass
+		assert not original_file_still_available
+
+		assert d == b2
+
+
+	def test_rename_exchange(self):
+		test_file1 = '/test_xchg1'
+		test_file2 = '/test_xchg2'
+		fs = Fatx('xbox_hdd.img')
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		fs.rename(test_file2, test_file1, exchange=True)
+
+		d1 = fs.read(test_file1)
+		d2 = fs.read(test_file2)
+
+		fs.unlink(test_file1)
+		fs.unlink(test_file2)
+
+		assert d1 == b2
+		assert d2 == b1
+
+
+	def test_rename_exchange_different_dirname_overwrite(self):
+		test_file1 = '/test_xchg1'
+		file2_dir = '/testdir'
+		test_file2 = '{}/test_xchg2'.format(file2_dir)
+		fs = Fatx('xbox_hdd.img')
+
+		fs.mkdir(file2_dir)
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		fs.rename(test_file2, test_file1, exchange=True)
+
+		d1 = fs.read(test_file1)
+		d2 = fs.read(test_file2)
+
+		fs.unlink(test_file1)
+		fs.unlink(test_file2)
+		
+		fs.rmdir(file2_dir)
+
+		assert d1 == b2
+		assert d2 == b1
+
+
+	def test_rename_different_dirname_overwrite(self):
+		test_file1 = '/test_xchg1'
+		file2_dir = '/testdir'
+		test_file2 = '{}/test_xchg2'.format(file2_dir)
+		fs = Fatx('xbox_hdd.img')
+
+		fs.mkdir(file2_dir)
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		fs.rename(test_file2, test_file1)
+
+		d1 = fs.read(test_file1)
+		fs.unlink(test_file1)
+
+		fs.rmdir(file2_dir)
+
+		original_file_still_available = False
+		try:
+			fs.get_attr(test_file2)
+			original_file_still_available = True
+		except AssertionError:
+			pass
+		assert not original_file_still_available
+
+		assert d1 == b2
+
+
+	def test_rename_different_dirname_nonexisting(self):
+		test_file1 = '/test_xchg1'
+		file2_dir = '/testdir'
+		test_file2 = '{}/test_xchg2'.format(file2_dir)
+		fs = Fatx('xbox_hdd.img')
+
+		fs.mkdir(file2_dir)
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		fs.rename(test_file2, test_file1)
+
+		d1 = fs.read(test_file1)
+		fs.unlink(test_file1)
+
+		fs.rmdir(file2_dir)
+
+		original_file_still_available = False
+		try:
+			fs.get_attr(test_file2)
+			original_file_still_available = True
+		except AssertionError:
+			pass
+		assert not original_file_still_available
+
+		assert d1 == b2
+
+
+	def test_rename_no_replace_different_dirname_nonexisting(self):
+		test_file1 = '/test_xchg1'
+		file2_dir = '/testdir'
+		test_file2 = '{}/test_xchg2'.format(file2_dir)
+		fs = Fatx('xbox_hdd.img')
+
+		fs.mkdir(file2_dir)
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		fs.rename(test_file2, test_file1, no_replace=True)
+
+		d1 = fs.read(test_file1)
+		fs.unlink(test_file1)
+
+		fs.rmdir(file2_dir)
+
+		original_file_still_available = False
+		try:
+			fs.get_attr(test_file2)
+			original_file_still_available = True
+		except AssertionError:
+			pass
+		assert not original_file_still_available
+
+		assert d1 == b2
+
+
+	def test_rename_no_replace_different_dirname_existing_fails(self):
+		test_file1 = '/test_xchg1'
+		file2_dir = '/testdir'
+		test_file2 = '{}/test_xchg2'.format(file2_dir)
+		fs = Fatx('xbox_hdd.img')
+
+		fs.mkdir(file2_dir)
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		rename_failed = False
+		try:
+			fs.rename(test_file2, test_file1, no_replace=True)
+			rename_failed = True
+		except AssertionError:
+			pass
+
+		fs.unlink(test_file1)
+		fs.unlink(test_file2)
+
+		fs.rmdir(file2_dir)
+
+		assert not rename_failed
+
+
+	def test_rename_exchange_nonexistent_file_fails(self):
+		test_file1 = '/test_xchg1'
+		test_file2 = '/test_xchg2'
+		fs = Fatx('xbox_hdd.img')
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		rename_failed = False
+		try:
+			fs.rename(test_file1, test_file2, exchange=True)
+			rename_failed = True
+		except AssertionError:
+			pass
+
+		if rename_failed:
+			fs.unlink(test_file2)
+		else:
+			fs.unlink(test_file1)
+
+		assert not rename_failed
+
+
+	def test_rename_no_replace_does_not_replace_file(self):
+		test_file1 = '/test_xchg1'
+		test_file2 = '/test_xchg2'
+		fs = Fatx('xbox_hdd.img')
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		b2 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file2, b2)
+
+		rename_failed = False
+		try:
+			fs.rename(test_file2, test_file1, no_replace=True)
+			rename_failed = True
+		except AssertionError:
+			pass
+
+		fs.unlink(test_file1)
+		fs.unlink(test_file2)
+
+		assert not rename_failed
+
+
+	def test_rename_no_replace_with_nonexistent_destination_works(self):
+		test_file1 = '/test_xchg1'
+		test_file2 = '/test_xchg2'
+		fs = Fatx('xbox_hdd.img')
+
+		rng = random.Random()
+		rng.seed(12345)
+
+		b1 = bytes([rng.getrandbits(8) for _ in range(1024)])
+		fs.write(test_file1, b1)
+
+		fs.rename(test_file1, test_file2, no_replace=True)
+
+		d2 = fs.read(test_file2)
+
+		fs.unlink(test_file2)
+
+		original_file_still_available = False
+		try:
+			fs.get_attr(test_file1)
+			original_file_still_available = True
+		except AssertionError:
+			pass
+		assert not original_file_still_available
+
+		assert d2 == b1
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Resolves a bug where overwriting a file using rename will not remove the old file, leaving two directory entries with the same name.

Ran into this when working on a libfuse3 upgrade, which is why `exchange` and `no_replace` are present. I split this off because it was worthy of its own PR.