### PR TITLE
libfatx: Fix corruption when fatx_read size>bytes_per_cluster

### DIFF
--- a/libfatx/fatx_file.c
+++ b/libfatx/fatx_file.c
@@ -140,7 +140,7 @@ int fatx_read(struct fatx_fs *fs, char const *path, off_t offset, size_t size, v
             break;
         }
 
-        bytes_to_read = MIN(fs->bytes_per_cluster, size-total_bytes_read);
+        bytes_to_read = MIN(fs->bytes_per_cluster - cluster_offset, size-total_bytes_read);
         bytes_to_read = MIN(bytes_to_read, bytes_remaining_in_file);
 
         if (bytes_to_read == 0)


### PR DESCRIPTION
Im interacting with libfatx directly reading in a file ~4Mb then doing a CRC.

```
// Works okay
size_t offset = 0;
do {
  bytes_read = fatx_read(fs, "myfile.bin", offset , 16384, &buffer[offset]);`
  offset  += bytes_read
while (bytes_read > 0);
```
however

```
// CRC mismatch
size_t offset = 0;
do {
  bytes_read = fatx_read(fs, "myfile.bin", offset, 16384+1, &buffer[offset]);`
  offset  += bytes_read
while (bytes_read > 0);
```

We appear to be doing it right in `fatx_write()`
https://github.com/mborgerson/fatx/blob/6777224d8dab4f25629336dd775a1b6c7f1c6ed6/libfatx/fatx_file.c#L246


This change fixes is.



Partition info below:

```
Device Path:         /C
  Partition Offset:    0x8ca80000 bytes
  Partition Size:      0x1f400000 bytes
  Volume Id:           5b206ddb
  Bytes per Sector:    512
  # of Sectors:        1024000
  Sectors per Cluster: 32
  # of Clusters:       31996
  Bytes per Cluster:   16384
  FAT Offset:          0x8ca81000 bytes
  FAT Size:            0x10000 bytes
  FAT Type:            16
  Root Cluster:        1
  Cluster Offset:      0x8ca91000 bytes
  ```

