### PR TITLE
rust/ci: Add clippy/fmt presubmit checks

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -35,3 +35,13 @@ jobs:
       run: |
         cd rust
         cargo build --release
+
+    - name: Check formatting
+      run: |
+        cd rust
+        cargo fmt -- --check
+
+    - name: Check lints
+      run: |
+        cd rust
+        cargo clippy -- -D warnings

--- a/rust/fatx/src/dir.rs
+++ b/rust/fatx/src/dir.rs
@@ -48,10 +48,7 @@ pub enum DirectoryEntryKind {
 }
 
 impl DirectoryEntry {
-    pub fn from_path<P: AsRef<Path>>(
-        fs: &mut FatxFs,
-        path: P,
-    ) -> Result<Self, Error> {
+    pub fn from_path<P: AsRef<Path>>(fs: &mut FatxFs, path: P) -> Result<Self, Error> {
         let path = normalize_virtual_path(path);
         let num_components = path.components().count();
 

--- a/rust/fatx/src/lib.rs
+++ b/rust/fatx/src/lib.rs
@@ -7,9 +7,9 @@ pub mod fs;
 pub mod partition;
 pub mod path;
 
+pub use datetime::DateTime;
 pub use dir::DirectoryEntry;
 pub use error::Error;
 pub use file::File;
-pub use fs::{FatxFsConfig as FatxFsConfig, FatxFs, FatxFsHandle};
+pub use fs::{FatxFs, FatxFsConfig, FatxFsHandle};
 pub use partition::{DEFAULT_PARTITION_LAYOUT, PartitionMapEntry};
-pub use datetime::DateTime;

--- a/rust/fatx/src/partition.rs
+++ b/rust/fatx/src/partition.rs
@@ -34,6 +34,8 @@ pub const DEFAULT_PARTITION_LAYOUT: &[PartitionMapEntry] = &[
 
 impl PartitionMapEntry {
     pub fn from_letter(letter: &str) -> Option<&PartitionMapEntry> {
-        DEFAULT_PARTITION_LAYOUT.iter().find(|&entry| entry.letter == letter)
+        DEFAULT_PARTITION_LAYOUT
+            .iter()
+            .find(|&entry| entry.letter == letter)
     }
 }


### PR DESCRIPTION
Also applies `cargo fmt` to the codebase. There were no clippy lints to apply.