### PR TITLE
cmake: Update minimum version to allow building with CMake 4+

### DIFF
--- a/fatxfs/CMakeLists.txt
+++ b/fatxfs/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project(fatxfs)
 

--- a/gfatx/CMakeLists.txt
+++ b/gfatx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project(gfatx LANGUAGES CXX)
 

--- a/libfatx/CMakeLists.txt
+++ b/libfatx/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project(libfatx VERSION 1.0)
 


### PR DESCRIPTION
pyfatx can't be installed on Windows with the latest CMake release due to removal of support for CMake 3.5 and below features.

```
     -- Building for: NMake Makefiles
      CMake Error at CMakeLists.txt:18 (cmake_minimum_required):
        Compatibility with CMake < 3.5 has been removed from CMake.

        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.

        Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```