### PR TITLE
Add FATX support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+install/
+*.img

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ install/
 __pycache__/
 *.pyc
 venv/
+gate-results/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 *.pyc
 venv/
 gate-results/
+src/
+pkg/
+*.pkg.tar.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build/
 install/
 *.img
+__pycache__/
+*.pyc
+venv/

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Mijael Viricochea <omensight@gmail.com>
+#
+# Local package: builds fatx360 (mborgerson/fatx + Xbox 360 read/write
+# support) directly from this checked-out working tree, uncommitted
+# changes included. Run `makepkg -si` from the repository root.
+
+pkgname=fatx360
+pkgver=r4e45a5e
+pkgrel=1
+pkgdesc="FUSE driver for FATX filesystems, with Xbox 360 (big-endian) read/write support"
+arch=('x86_64')
+url="https://github.com/mborgerson/fatx"
+license=('GPL2')
+depends=('fuse2')
+makedepends=('cmake' 'pkgconf')
+provides=('mount.fatxfs')
+options=('!strip')
+
+build() {
+    local stage="$srcdir/stage"
+
+    cmake -S "$startdir/libfatx" -B "$srcdir/build-libfatx" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$stage"
+    cmake --build "$srcdir/build-libfatx"
+    cmake --install "$srcdir/build-libfatx"
+
+    cmake -S "$startdir/fatxfs" -B "$srcdir/build-fatxfs" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="$stage" \
+        -DCMAKE_INSTALL_PREFIX=/usr
+    cmake --build "$srcdir/build-fatxfs"
+}
+
+package() {
+    DESTDIR="$pkgdir" cmake --install "$srcdir/build-fatxfs"
+
+    # mount(8) helper: lets `mount -t fatxfs` / fstab entries find the driver,
+    # the same way ntfs-3g installs mount.ntfs-3g next to its own binary.
+    ln -s fatxfs "$pkgdir/usr/bin/mount.fatxfs"
+
+    install -Dm644 "$startdir/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ There is work-in-progress towards a Rust implementation:
 * [**fatx**](rust/fatx/README.md) is a Rust crate for working with the FATX filesystem, like libfatx.
 * [**fatx-fuse**](rust/fatx-fuse/README.md) is a Rust crate providing a FUSE driver based on fuser and fatx.
 
+Xbox 360 Support
+-----------------
+This adds full read/write support for the Xbox 360's FATX filesystem to libfatx, fatxfs, pyfatx, and the Rust implementation. The 360 uses the same on-disk format as the original Xbox but differs in four ways — byte order (big-endian vs. little-endian), timestamp epoch, timestamp field widths, and date/time field ordering — all of which are now handled automatically via variant auto-detection. Original Xbox support is unchanged and remains fully compatible.
+
+The write path has been verified end-to-end against real Xbox 360 hardware.
+
 License
 -------
 See LICENSE.txt

--- a/fatxfs/fatxfs_fuse.c
+++ b/fatxfs/fatxfs_fuse.c
@@ -641,7 +641,13 @@ int fatx_fuse_opt_proc(void *data, const char *arg, int key, struct fuse_args *o
         return 0;
 
     case FATX_FUSE_OPT_KEY_PARTITION:
-        pd->mount_partition_name = fatx_fuse_opt_consume_key(arg);
+        /*
+         * Must be duplicated: when this option arrives via -o (as it does
+         * from an fstab-invoked mount helper), arg points into a buffer
+         * libfuse reuses once the whole -o group is processed, so a raw
+         * pointer here would dangle by the time main() reads it back.
+         */
+        pd->mount_partition_name = strdup(fatx_fuse_opt_consume_key(arg));
         return 0;
 
     case FATX_FUSE_OPT_KEY_READ_ONLY:
@@ -690,7 +696,8 @@ int fatx_fuse_opt_proc(void *data, const char *arg, int key, struct fuse_args *o
         return 0;
 
     case FATX_FUSE_OPT_KEY_LOG:
-        pd->log_path = fatx_fuse_opt_consume_key(arg);
+        /* See FATX_FUSE_OPT_KEY_PARTITION: must be duplicated for -o safety. */
+        pd->log_path = strdup(fatx_fuse_opt_consume_key(arg));
         return 0;
 
     case FATX_FUSE_OPT_KEY_LOGLEVEL:
@@ -732,7 +739,9 @@ void fatx_fuse_print_usage(void)
     fprintf(stderr, "   or: %s <device> <mountpoint> --variant=x360 --partition=<name> [<options>]\n", prog_short_name);
     fprintf(stderr, "   or: %s <device> <mountpoint> --offset=<offset> --size=<size> [<options>]\n\n", prog_short_name);
     fprintf(stderr, "General options:\n"
-                    "    -o opt, [opt...]               mount options\n"
+                    "    -o opt, [opt...]               mount options (FATXFS options below may also\n"
+                    "                                    be given here without their -- prefix, e.g.\n"
+                    "                                    -o variant=x360,partition=data)\n"
                     "    -h --help                      print help\n"
                     "    -V --version                   print version\n\n"
                     "FATXFS options:\n"
@@ -773,18 +782,36 @@ int main(int argc, char *argv[])
         FUSE_OPT_KEY("--help",                       FATX_FUSE_OPT_KEY_HELP),
         FUSE_OPT_KEY("-V",                           FATX_FUSE_OPT_KEY_VERSION),
         FUSE_OPT_KEY("--version",                    FATX_FUSE_OPT_KEY_VERSION),
+        /*
+         * Each FATXFS option is matched both as a "--long=value" argument and
+         * as a bare "key=value" mount suboption, since mount(8) invokes
+         * mount helpers (e.g. from fstab) as `mount.fatxfs dev mnt -o
+         * key=value,...` rather than with "--" prefixed flags.
+         */
         FUSE_OPT_KEY("--drive=",                     FATX_FUSE_OPT_KEY_DRIVE),
+        FUSE_OPT_KEY("drive=",                       FATX_FUSE_OPT_KEY_DRIVE),
         FUSE_OPT_KEY("--variant=",                   FATX_FUSE_OPT_KEY_VARIANT),
+        FUSE_OPT_KEY("variant=",                     FATX_FUSE_OPT_KEY_VARIANT),
         FUSE_OPT_KEY("--partition=",                 FATX_FUSE_OPT_KEY_PARTITION),
+        FUSE_OPT_KEY("partition=",                   FATX_FUSE_OPT_KEY_PARTITION),
         FUSE_OPT_KEY("--read-only",                  FATX_FUSE_OPT_KEY_READ_ONLY),
+        FUSE_OPT_KEY("read-only",                    FATX_FUSE_OPT_KEY_READ_ONLY),
         FUSE_OPT_KEY("--offset=",                    FATX_FUSE_OPT_KEY_OFFSET),
+        FUSE_OPT_KEY("offset=",                      FATX_FUSE_OPT_KEY_OFFSET),
         FUSE_OPT_KEY("--size=",                      FATX_FUSE_OPT_KEY_SIZE),
+        FUSE_OPT_KEY("size=",                        FATX_FUSE_OPT_KEY_SIZE),
         FUSE_OPT_KEY("--sector-size=",               FATX_FUSE_OPT_KEY_SECTOR_SIZE),
+        FUSE_OPT_KEY("sector-size=",                 FATX_FUSE_OPT_KEY_SECTOR_SIZE),
         FUSE_OPT_KEY("--format=" ,                   FATX_FUSE_OPT_KEY_FORMAT),
+        FUSE_OPT_KEY("format=" ,                     FATX_FUSE_OPT_KEY_FORMAT),
         FUSE_OPT_KEY("--sectors-per-cluster=" ,      FATX_FUSE_OPT_KEY_SECTORS_PER_CLUSTER),
+        FUSE_OPT_KEY("sectors-per-cluster=" ,        FATX_FUSE_OPT_KEY_SECTORS_PER_CLUSTER),
         FUSE_OPT_KEY("--destroy-all-existing-data",  FATX_FUSE_OPT_KEY_DESTROY_DATA),
+        FUSE_OPT_KEY("destroy-all-existing-data",    FATX_FUSE_OPT_KEY_DESTROY_DATA),
         FUSE_OPT_KEY("--log=",                       FATX_FUSE_OPT_KEY_LOG),
+        FUSE_OPT_KEY("log=",                         FATX_FUSE_OPT_KEY_LOG),
         FUSE_OPT_KEY("--loglevel=",                  FATX_FUSE_OPT_KEY_LOGLEVEL),
+        FUSE_OPT_KEY("loglevel=",                    FATX_FUSE_OPT_KEY_LOGLEVEL),
         FUSE_OPT_END,
     };
 

--- a/fatxfs/fatxfs_fuse.c
+++ b/fatxfs/fatxfs_fuse.c
@@ -41,6 +41,7 @@ enum {
     FATX_FUSE_OPT_KEY_DRIVE,
     FATX_FUSE_OPT_KEY_VARIANT,
     FATX_FUSE_OPT_KEY_PARTITION,
+    FATX_FUSE_OPT_KEY_READ_ONLY,
     FATX_FUSE_OPT_KEY_OFFSET,
     FATX_FUSE_OPT_KEY_SIZE,
     FATX_FUSE_OPT_KEY_SECTOR_SIZE,
@@ -59,6 +60,7 @@ struct fatx_fuse_private_data {
     char              mount_partition_drive;
     char const       *mount_partition_name;
     enum fatx_variant variant;
+    int               read_only;
     size_t            mount_partition_offset;
     size_t            mount_partition_size;
     size_t            device_sector_size;
@@ -642,6 +644,10 @@ int fatx_fuse_opt_proc(void *data, const char *arg, int key, struct fuse_args *o
         pd->mount_partition_name = fatx_fuse_opt_consume_key(arg);
         return 0;
 
+    case FATX_FUSE_OPT_KEY_READ_ONLY:
+        pd->read_only = 1;
+        return 0;
+
     case FATX_FUSE_OPT_KEY_OFFSET:
         arg = fatx_fuse_opt_consume_key(arg);
         pd->mount_partition_offset = strtol(arg, NULL, 0);
@@ -733,6 +739,7 @@ void fatx_fuse_print_usage(void)
                     "    --drive=<letter>               mount an original Xbox partition by its drive letter\n"
                     "    --variant=<variant>            on-disk byte order: auto (default), xbox or x360\n"
                     "    --partition=<name>             mount an Xbox 360 partition by name (sysext, sysext2, compat, data)\n"
+                    "    --read-only                    open the device without write access at all (stronger than -o ro)\n"
                     "    --offset=<offset>              specify the offset (in bytes) of a partition manually\n"
                     "    --size=<size>                  specify the size (in bytes) of a partition manually\n"
                     "    --sector-size=<size>           specify the size (in bytes) of a device sector (default is 512)\n"
@@ -769,6 +776,7 @@ int main(int argc, char *argv[])
         FUSE_OPT_KEY("--drive=",                     FATX_FUSE_OPT_KEY_DRIVE),
         FUSE_OPT_KEY("--variant=",                   FATX_FUSE_OPT_KEY_VARIANT),
         FUSE_OPT_KEY("--partition=",                 FATX_FUSE_OPT_KEY_PARTITION),
+        FUSE_OPT_KEY("--read-only",                  FATX_FUSE_OPT_KEY_READ_ONLY),
         FUSE_OPT_KEY("--offset=",                    FATX_FUSE_OPT_KEY_OFFSET),
         FUSE_OPT_KEY("--size=",                      FATX_FUSE_OPT_KEY_SIZE),
         FUSE_OPT_KEY("--sector-size=",               FATX_FUSE_OPT_KEY_SECTOR_SIZE),
@@ -922,7 +930,8 @@ int main(int argc, char *argv[])
                                  pd.mount_partition_size,
                                  pd.device_sector_size,
                                  FATX_READ_FROM_SUPERBLOCK,
-                                 pd.variant);
+                                 pd.variant,
+                                 pd.read_only ? FATX_OPEN_READ_ONLY : 0);
     if (status)
     {
         fprintf(stderr, "failed to initialize the filesystem\n");

--- a/fatxfs/fatxfs_fuse.c
+++ b/fatxfs/fatxfs_fuse.c
@@ -39,6 +39,8 @@ enum {
     FATX_FUSE_OPT_KEY_HELP,
     FATX_FUSE_OPT_KEY_VERSION,
     FATX_FUSE_OPT_KEY_DRIVE,
+    FATX_FUSE_OPT_KEY_VARIANT,
+    FATX_FUSE_OPT_KEY_PARTITION,
     FATX_FUSE_OPT_KEY_OFFSET,
     FATX_FUSE_OPT_KEY_SIZE,
     FATX_FUSE_OPT_KEY_SECTOR_SIZE,
@@ -55,6 +57,8 @@ struct fatx_fuse_private_data {
     char const       *log_path;
     char             *mount_point;
     char              mount_partition_drive;
+    char const       *mount_partition_name;
+    enum fatx_variant variant;
     size_t            mount_partition_offset;
     size_t            mount_partition_size;
     size_t            device_sector_size;
@@ -613,6 +617,31 @@ int fatx_fuse_opt_proc(void *data, const char *arg, int key, struct fuse_args *o
         pd->mount_partition_drive = arg[0];
         return 0;
 
+    case FATX_FUSE_OPT_KEY_VARIANT:
+        arg = fatx_fuse_opt_consume_key(arg);
+        if (!strcmp(arg, "auto"))
+        {
+            pd->variant = FATX_VARIANT_AUTO;
+        }
+        else if (!strcmp(arg, "xbox"))
+        {
+            pd->variant = FATX_VARIANT_XBOX;
+        }
+        else if (!strcmp(arg, "x360"))
+        {
+            pd->variant = FATX_VARIANT_X360;
+        }
+        else
+        {
+            fprintf(stderr, "invalid variant '%s' specified (expected auto, xbox or x360)\n", arg);
+            return -1;
+        }
+        return 0;
+
+    case FATX_FUSE_OPT_KEY_PARTITION:
+        pd->mount_partition_name = fatx_fuse_opt_consume_key(arg);
+        return 0;
+
     case FATX_FUSE_OPT_KEY_OFFSET:
         arg = fatx_fuse_opt_consume_key(arg);
         pd->mount_partition_offset = strtol(arg, NULL, 0);
@@ -694,13 +723,16 @@ void fatx_fuse_print_usage(void)
     fprintf(stderr, "FATXFS - Userspace FATX Filesystem Driver\n\n");
     fprintf(stderr, "Usage: %s <device> <mountpoint> [<options>]\n", prog_short_name);
     fprintf(stderr, "   or: %s <device> <mountpoint> --drive=c|e|x|y|z|f [<options>]\n", prog_short_name);
+    fprintf(stderr, "   or: %s <device> <mountpoint> --variant=x360 --partition=<name> [<options>]\n", prog_short_name);
     fprintf(stderr, "   or: %s <device> <mountpoint> --offset=<offset> --size=<size> [<options>]\n\n", prog_short_name);
     fprintf(stderr, "General options:\n"
                     "    -o opt, [opt...]               mount options\n"
                     "    -h --help                      print help\n"
                     "    -V --version                   print version\n\n"
                     "FATXFS options:\n"
-                    "    --drive=<letter>               mount a partition by its drive letter\n"
+                    "    --drive=<letter>               mount an original Xbox partition by its drive letter\n"
+                    "    --variant=<variant>            on-disk byte order: auto (default), xbox or x360\n"
+                    "    --partition=<name>             mount an Xbox 360 partition by name (sysext, sysext2, compat, data)\n"
                     "    --offset=<offset>              specify the offset (in bytes) of a partition manually\n"
                     "    --size=<size>                  specify the size (in bytes) of a partition manually\n"
                     "    --sector-size=<size>           specify the size (in bytes) of a device sector (default is 512)\n"
@@ -735,6 +767,8 @@ int main(int argc, char *argv[])
         FUSE_OPT_KEY("-V",                           FATX_FUSE_OPT_KEY_VERSION),
         FUSE_OPT_KEY("--version",                    FATX_FUSE_OPT_KEY_VERSION),
         FUSE_OPT_KEY("--drive=",                     FATX_FUSE_OPT_KEY_DRIVE),
+        FUSE_OPT_KEY("--variant=",                   FATX_FUSE_OPT_KEY_VARIANT),
+        FUSE_OPT_KEY("--partition=",                 FATX_FUSE_OPT_KEY_PARTITION),
         FUSE_OPT_KEY("--offset=",                    FATX_FUSE_OPT_KEY_OFFSET),
         FUSE_OPT_KEY("--size=",                      FATX_FUSE_OPT_KEY_SIZE),
         FUSE_OPT_KEY("--sector-size=",               FATX_FUSE_OPT_KEY_SECTOR_SIZE),
@@ -767,13 +801,32 @@ int main(int argc, char *argv[])
         goto error_nofs;
     }
 
+    if (pd.mount_partition_drive != 0x00 && pd.mount_partition_name != NULL)
+    {
+        fprintf(stderr, "--drive cannot be used with --partition\n");
+        goto error_nofs;
+    }
+
+    /*
+     * An Xbox 360 disk has no drive letters, so default it to the user content
+     * partition rather than to the original Xbox's 'c'.
+     */
+    if (pd.variant == FATX_VARIANT_X360 &&
+        pd.mount_partition_drive == 0x00 &&
+        pd.mount_partition_name == NULL &&
+        pd.mount_partition_offset == -1 &&
+        pd.mount_partition_size == -1)
+    {
+        pd.mount_partition_name = "data";
+    }
+
     if (pd.mount_partition_offset != -1 || pd.mount_partition_size != -1)
     {
         /* Partition Specified Manually */
 
-        if (pd.mount_partition_drive != 0x00)
+        if (pd.mount_partition_drive != 0x00 || pd.mount_partition_name != NULL)
         {
-            fprintf(stderr, "--drive cannot be used with --offset or --size\n");
+            fprintf(stderr, "--drive/--partition cannot be used with --offset or --size\n");
             goto error_nofs;
         }
 
@@ -786,6 +839,19 @@ int main(int argc, char *argv[])
         if (pd.mount_partition_size == -1)
         {
             fprintf(stderr, "please specify partition size\n");
+            goto error_nofs;
+        }
+    }
+    else if (pd.mount_partition_name != NULL)
+    {
+        /* Xbox 360 Partition Name Specified */
+        status = fatx_x360_partition_to_offset_size(pd.mount_partition_name,
+                                                    &pd.mount_partition_offset,
+                                                    &pd.mount_partition_size);
+        if (status)
+        {
+            fprintf(stderr, "unknown partition '%s' (expected one of: %s)\n",
+                    pd.mount_partition_name, fatx_x360_partition_names());
             goto error_nofs;
         }
     }
@@ -850,12 +916,13 @@ int main(int argc, char *argv[])
     }
 
     /* Open the device */
-    status = fatx_open_device(pd.fs,
-                              pd.device_path,
-                              pd.mount_partition_offset,
-                              pd.mount_partition_size,
-                              pd.device_sector_size,
-                              FATX_READ_FROM_SUPERBLOCK);
+    status = fatx_open_device_ex(pd.fs,
+                                 pd.device_path,
+                                 pd.mount_partition_offset,
+                                 pd.mount_partition_size,
+                                 pd.device_sector_size,
+                                 FATX_READ_FROM_SUPERBLOCK,
+                                 pd.variant);
     if (status)
     {
         fprintf(stderr, "failed to initialize the filesystem\n");

--- a/libfatx/fatx.c
+++ b/libfatx/fatx.c
@@ -25,9 +25,17 @@
 #include "fatx_internal.h"
 
 /*
- * Open a device.
+ * Open a device, detecting the FATX variant from the partition signature.
  */
 int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster)
+{
+    return fatx_open_device_ex(fs, path, offset, size, sector_size, sectors_per_cluster, FATX_VARIANT_AUTO);
+}
+
+/*
+ * Open a device, using the given FATX variant.
+ */
+int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster, enum fatx_variant variant)
 {
     int retval = 0;
 
@@ -61,6 +69,7 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint
     }
 
     fs->device_path      = path;
+    fs->variant          = variant;
     fs->sector_size      = sector_size;
     fs->partition_offset = offset;
     fs->partition_size   = size;
@@ -140,6 +149,7 @@ int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint
 
     fatx_info(fs, "Partition Info:\n");
     fatx_info(fs, "  Device Path:         %s\n",          fs->device_path);
+    fatx_info(fs, "  Variant:             %s\n",          fatx_variant_name(fs->variant));
     fatx_info(fs, "  Partition Offset:    0x%zx bytes\n", fs->partition_offset);
     fatx_info(fs, "  Partition Size:      0x%zx bytes\n", fs->partition_size);
     fatx_info(fs, "  Volume Id:           %.8x\n",        fs->volume_id);

--- a/libfatx/fatx.c
+++ b/libfatx/fatx.c
@@ -29,13 +29,13 @@
  */
 int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster)
 {
-    return fatx_open_device_ex(fs, path, offset, size, sector_size, sectors_per_cluster, FATX_VARIANT_AUTO);
+    return fatx_open_device_ex(fs, path, offset, size, sector_size, sectors_per_cluster, FATX_VARIANT_AUTO, 0);
 }
 
 /*
- * Open a device, using the given FATX variant.
+ * Open a device, using the given FATX variant and flags.
  */
-int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster, enum fatx_variant variant)
+int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster, enum fatx_variant variant, unsigned int flags)
 {
     int retval = 0;
 
@@ -70,16 +70,18 @@ int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, u
 
     fs->device_path      = path;
     fs->variant          = variant;
+    fs->read_only        = (flags & FATX_OPEN_READ_ONLY) != 0;
     fs->sector_size      = sector_size;
     fs->partition_offset = offset;
     fs->partition_size   = size;
 
     memset(&fs->fat_cache, 0, sizeof(fs->fat_cache));
 
-    fs->device = fopen(fs->device_path, "r+b");
+    fs->device = fopen(fs->device_path, fs->read_only ? "rb" : "r+b");
     if (!fs->device)
     {
-        fatx_error(fs, "failed to open %s for reading and writing\n", path);
+        fatx_error(fs, "failed to open %s for %s\n", path,
+                   fs->read_only ? "reading" : "reading and writing");
         return FATX_STATUS_ERROR;
     }
 

--- a/libfatx/fatx.h
+++ b/libfatx/fatx.h
@@ -65,6 +65,19 @@ extern "C" {
 
 #define FATX_FAT_CACHE_NUM_ENTRIES   512
 
+/*
+ * Which console's flavour of FATX a filesystem is.
+ *
+ * The two are the same filesystem with opposite on-disk byte order. AUTO probes
+ * the partition signature to work out which, and is what fatx_open_device uses;
+ * pass an explicit variant to fatx_open_device_ex to skip the probe.
+ */
+enum fatx_variant {
+    FATX_VARIANT_AUTO = 0, /* detect from the partition signature */
+    FATX_VARIANT_XBOX,     /* original Xbox, little-endian on disk */
+    FATX_VARIANT_X360      /* Xbox 360, big-endian on disk */
+};
+
 struct fatx_cache {
     size_t position;
     size_t entries;
@@ -76,6 +89,7 @@ struct fatx_cache {
 struct fatx_fs {
     char const       *device_path;
     FILE             *device;
+    enum fatx_variant variant;
     size_t            sector_size;
     uint64_t          partition_offset;
     uint64_t          partition_size;
@@ -132,6 +146,19 @@ struct fatx_partition_map_entry {
     uint64_t size;
 };
 
+/*
+ * Xbox 360 Harddisk Partition Map
+ *
+ * The 360 has no MBR/GPT and no drive letters: partitions live at fixed offsets
+ * and are identified here by name.
+ */
+
+struct fatx_x360_partition_map_entry {
+    char const *name;
+    uint64_t    offset;
+    uint64_t    size;
+};
+
 enum fatx_format {
     FATX_FORMAT_INVALID,
     FATX_FORMAT_RETAIL,
@@ -140,6 +167,7 @@ enum fatx_format {
 
 /* FATX Functions */
 int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster);
+int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster, enum fatx_variant variant);
 int fatx_close_device(struct fatx_fs *fs);
 int fatx_open_dir(struct fatx_fs *fs, char const *path, struct fatx_dir *dir);
 int fatx_read_dir(struct fatx_fs *fs, struct fatx_dir *dir, struct fatx_dirent *entry, struct fatx_attr *attr, struct fatx_dirent **result);
@@ -169,6 +197,8 @@ int fatx_disk_size_remaining(char const *path, uint64_t offset, uint64_t *size);
 int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, enum fatx_format format_type, size_t sectors_per_cluster);
 int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster);
 int fatx_drive_to_offset_size(char drive_letter, uint64_t *offset, uint64_t *size);
+int fatx_x360_partition_to_offset_size(char const *name, uint64_t *offset, uint64_t *size);
+char const *fatx_x360_partition_names(void);
 int fatx_disk_write_refurb_info(char const *path, uint32_t number_of_boots, uint64_t first_power_on);
 
 /* Misc Functions */

--- a/libfatx/fatx.h
+++ b/libfatx/fatx.h
@@ -78,6 +78,16 @@ enum fatx_variant {
     FATX_VARIANT_X360      /* Xbox 360, big-endian on disk */
 };
 
+/*
+ * Flags for fatx_open_device_ex.
+ *
+ * FATX_OPEN_READ_ONLY opens the underlying device without write access at all,
+ * and makes the library refuse every write. FUSE's own -o ro does not do this:
+ * it stops the kernel issuing writes, but the device is still opened
+ * read-write, so a bug in the driver could still reach the disk.
+ */
+#define FATX_OPEN_READ_ONLY (1u<<0)
+
 struct fatx_cache {
     size_t position;
     size_t entries;
@@ -90,6 +100,7 @@ struct fatx_fs {
     char const       *device_path;
     FILE             *device;
     enum fatx_variant variant;
+    int               read_only;
     size_t            sector_size;
     uint64_t          partition_offset;
     uint64_t          partition_size;
@@ -167,7 +178,7 @@ enum fatx_format {
 
 /* FATX Functions */
 int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster);
-int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster, enum fatx_variant variant);
+int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster, enum fatx_variant variant, unsigned int flags);
 int fatx_close_device(struct fatx_fs *fs);
 int fatx_open_dir(struct fatx_fs *fs, char const *path, struct fatx_dir *dir);
 int fatx_read_dir(struct fatx_fs *fs, struct fatx_dir *dir, struct fatx_dirent *entry, struct fatx_attr *attr, struct fatx_dirent **result);

--- a/libfatx/fatx_attr.c
+++ b/libfatx/fatx_attr.c
@@ -52,6 +52,8 @@ int fatx_attr_to_dirent(struct fatx_fs *fs, struct fatx_attr *attr, struct fatx_
 
     entry->filename_len = filename_len;
     memcpy(entry->filename, attr->filename, filename_len);
+    /* Pad the unused tail, so stack contents are not written out to disk. */
+    memset(entry->filename + filename_len, 0xFF, sizeof(entry->filename) - filename_len);
 
     entry->attributes    = attr->attributes;
     entry->first_cluster = fatx_to_disk_u32(fs, attr->first_cluster);

--- a/libfatx/fatx_attr.c
+++ b/libfatx/fatx_attr.c
@@ -29,15 +29,15 @@ int fatx_dirent_to_attr(struct fatx_fs *fs, struct fatx_raw_directory_entry *ent
     attr->filename[entry->filename_len] = '\0';
 
     attr->attributes    = entry->attributes;
-    attr->first_cluster = entry->first_cluster;
-    attr->file_size     = entry->file_size;
+    attr->first_cluster = fatx_from_disk_u32(fs, entry->first_cluster);
+    attr->file_size     = fatx_from_disk_u32(fs, entry->file_size);
 
-    fatx_unpack_date(entry->modified_date, &(attr->modified));
-    fatx_unpack_time(entry->modified_time, &(attr->modified));
-    fatx_unpack_date(entry->created_date,  &(attr->created));
-    fatx_unpack_time(entry->created_time,  &(attr->created));
-    fatx_unpack_date(entry->accessed_date, &(attr->accessed));
-    fatx_unpack_time(entry->accessed_time, &(attr->accessed));
+    fatx_unpack_date(fatx_from_disk_u16(fs, entry->modified_date), &(attr->modified));
+    fatx_unpack_time(fatx_from_disk_u16(fs, entry->modified_time), &(attr->modified));
+    fatx_unpack_date(fatx_from_disk_u16(fs, entry->created_date),  &(attr->created));
+    fatx_unpack_time(fatx_from_disk_u16(fs, entry->created_time),  &(attr->created));
+    fatx_unpack_date(fatx_from_disk_u16(fs, entry->accessed_date), &(attr->accessed));
+    fatx_unpack_time(fatx_from_disk_u16(fs, entry->accessed_time), &(attr->accessed));
 
     return FATX_STATUS_SUCCESS;
 }
@@ -48,19 +48,34 @@ int fatx_dirent_to_attr(struct fatx_fs *fs, struct fatx_raw_directory_entry *ent
 int fatx_attr_to_dirent(struct fatx_fs *fs, struct fatx_attr *attr, struct fatx_raw_directory_entry *entry)
 {
     size_t filename_len = strlen(attr->filename);
+    uint16_t date, time;
+
     entry->filename_len = filename_len;
     memcpy(entry->filename, attr->filename, filename_len);
 
     entry->attributes    = attr->attributes;
-    entry->first_cluster = attr->first_cluster;
-    entry->file_size     = attr->file_size;
+    entry->first_cluster = fatx_to_disk_u32(fs, attr->first_cluster);
+    entry->file_size     = fatx_to_disk_u32(fs, attr->file_size);
 
-    fatx_pack_date(&(attr->modified), &(entry->modified_date));
-    fatx_pack_time(&(attr->modified), &(entry->modified_time));
-    fatx_pack_date(&(attr->created),  &(entry->created_date));
-    fatx_pack_time(&(attr->created),  &(entry->created_time));
-    fatx_pack_date(&(attr->accessed), &(entry->accessed_date));
-    fatx_pack_time(&(attr->accessed), &(entry->accessed_time));
+    /*
+     * Pack into locals rather than straight into the packed on-disk struct, so
+     * the value can be byte-swapped on the way in (and so the packers are not
+     * handed a potentially unaligned pointer).
+     */
+    fatx_pack_date(&(attr->modified), &date);
+    fatx_pack_time(&(attr->modified), &time);
+    entry->modified_date = fatx_to_disk_u16(fs, date);
+    entry->modified_time = fatx_to_disk_u16(fs, time);
+
+    fatx_pack_date(&(attr->created), &date);
+    fatx_pack_time(&(attr->created), &time);
+    entry->created_date = fatx_to_disk_u16(fs, date);
+    entry->created_time = fatx_to_disk_u16(fs, time);
+
+    fatx_pack_date(&(attr->accessed), &date);
+    fatx_pack_time(&(attr->accessed), &time);
+    entry->accessed_date = fatx_to_disk_u16(fs, date);
+    entry->accessed_time = fatx_to_disk_u16(fs, time);
 
     return FATX_STATUS_SUCCESS;
 }

--- a/libfatx/fatx_attr.c
+++ b/libfatx/fatx_attr.c
@@ -21,6 +21,60 @@
 #include <stdlib.h>
 
 /*
+ * Read one on-disk timestamp pair.
+ *
+ * slot0 and slot1 are the two 16-bit halves in the order they appear on disk.
+ * The original Xbox stores time then date; the Xbox 360 stores date then time.
+ */
+static void fatx_unpack_timestamp(struct fatx_fs *fs, uint16_t slot0, uint16_t slot1, struct fatx_ts *out)
+{
+    uint16_t date, time;
+
+    if (fs->variant == FATX_VARIANT_X360)
+    {
+        date = slot0;
+        time = slot1;
+    }
+    else
+    {
+        time = slot0;
+        date = slot1;
+    }
+
+    fatx_unpack_date(fs, fatx_from_disk_u16(fs, date), out);
+    fatx_unpack_time(fs, fatx_from_disk_u16(fs, time), out);
+}
+
+/*
+ * Write one on-disk timestamp pair, in this filesystem's slot order.
+ *
+ * Packing goes through locals rather than straight into the packed on-disk
+ * struct so the values can be byte-swapped on the way in, and so the packers
+ * are never handed a potentially unaligned pointer.
+ */
+static void fatx_pack_timestamp(struct fatx_fs *fs, struct fatx_ts *in, uint16_t *slot0, uint16_t *slot1)
+{
+    uint16_t date, time;
+
+    fatx_pack_date(fs, in, &date);
+    fatx_pack_time(fs, in, &time);
+
+    date = fatx_to_disk_u16(fs, date);
+    time = fatx_to_disk_u16(fs, time);
+
+    if (fs->variant == FATX_VARIANT_X360)
+    {
+        *slot0 = date;
+        *slot1 = time;
+    }
+    else
+    {
+        *slot0 = time;
+        *slot1 = date;
+    }
+}
+
+/*
  * Populate a fatx_attr struct given a low-level directory entry.
  */
 int fatx_dirent_to_attr(struct fatx_fs *fs, struct fatx_raw_directory_entry *entry, struct fatx_attr *attr)
@@ -32,12 +86,9 @@ int fatx_dirent_to_attr(struct fatx_fs *fs, struct fatx_raw_directory_entry *ent
     attr->first_cluster = fatx_from_disk_u32(fs, entry->first_cluster);
     attr->file_size     = fatx_from_disk_u32(fs, entry->file_size);
 
-    fatx_unpack_date(fatx_from_disk_u16(fs, entry->modified_date), &(attr->modified));
-    fatx_unpack_time(fatx_from_disk_u16(fs, entry->modified_time), &(attr->modified));
-    fatx_unpack_date(fatx_from_disk_u16(fs, entry->created_date),  &(attr->created));
-    fatx_unpack_time(fatx_from_disk_u16(fs, entry->created_time),  &(attr->created));
-    fatx_unpack_date(fatx_from_disk_u16(fs, entry->accessed_date), &(attr->accessed));
-    fatx_unpack_time(fatx_from_disk_u16(fs, entry->accessed_time), &(attr->accessed));
+    fatx_unpack_timestamp(fs, entry->modified_time, entry->modified_date, &(attr->modified));
+    fatx_unpack_timestamp(fs, entry->created_time,  entry->created_date,  &(attr->created));
+    fatx_unpack_timestamp(fs, entry->accessed_time, entry->accessed_date, &(attr->accessed));
 
     return FATX_STATUS_SUCCESS;
 }
@@ -48,7 +99,6 @@ int fatx_dirent_to_attr(struct fatx_fs *fs, struct fatx_raw_directory_entry *ent
 int fatx_attr_to_dirent(struct fatx_fs *fs, struct fatx_attr *attr, struct fatx_raw_directory_entry *entry)
 {
     size_t filename_len = strlen(attr->filename);
-    uint16_t date, time;
 
     entry->filename_len = filename_len;
     memcpy(entry->filename, attr->filename, filename_len);
@@ -59,25 +109,9 @@ int fatx_attr_to_dirent(struct fatx_fs *fs, struct fatx_attr *attr, struct fatx_
     entry->first_cluster = fatx_to_disk_u32(fs, attr->first_cluster);
     entry->file_size     = fatx_to_disk_u32(fs, attr->file_size);
 
-    /*
-     * Pack into locals rather than straight into the packed on-disk struct, so
-     * the value can be byte-swapped on the way in (and so the packers are not
-     * handed a potentially unaligned pointer).
-     */
-    fatx_pack_date(&(attr->modified), &date);
-    fatx_pack_time(&(attr->modified), &time);
-    entry->modified_date = fatx_to_disk_u16(fs, date);
-    entry->modified_time = fatx_to_disk_u16(fs, time);
-
-    fatx_pack_date(&(attr->created), &date);
-    fatx_pack_time(&(attr->created), &time);
-    entry->created_date = fatx_to_disk_u16(fs, date);
-    entry->created_time = fatx_to_disk_u16(fs, time);
-
-    fatx_pack_date(&(attr->accessed), &date);
-    fatx_pack_time(&(attr->accessed), &time);
-    entry->accessed_date = fatx_to_disk_u16(fs, date);
-    entry->accessed_time = fatx_to_disk_u16(fs, time);
+    fatx_pack_timestamp(fs, &(attr->modified), &(entry->modified_time), &(entry->modified_date));
+    fatx_pack_timestamp(fs, &(attr->created),  &(entry->created_time),  &(entry->created_date));
+    fatx_pack_timestamp(fs, &(attr->accessed), &(entry->accessed_time), &(entry->accessed_date));
 
     return FATX_STATUS_SUCCESS;
 }

--- a/libfatx/fatx_dev.c
+++ b/libfatx/fatx_dev.c
@@ -73,5 +73,16 @@ size_t fatx_dev_read(struct fatx_fs *fs, void *buf, size_t size, size_t items)
 size_t fatx_dev_write(struct fatx_fs *fs, const void *buf, size_t size, size_t items)
 {
     fatx_debug(fs, "fatx_dev_write(buf=0x%p, size=0x%zx, items=0x%zx)\n", buf, size, items);
+
+    /*
+     * Every write in the library funnels through here, so this one check is
+     * enough to guarantee a read-only filesystem never touches the device.
+     */
+    if (fs->read_only)
+    {
+        fatx_error(fs, "refusing to write to a read-only filesystem\n");
+        return 0;
+    }
+
     return fwrite(buf, size, items, fs->device);
 }

--- a/libfatx/fatx_dir.c
+++ b/libfatx/fatx_dir.c
@@ -220,7 +220,7 @@ int fatx_read_dir(struct fatx_fs *fs, struct fatx_dir *dir, struct fatx_dirent *
         return FATX_STATUS_FILE_DELETED;
     }
 
-    fatx_debug(fs, "dirent %zd of cluster %zd data starts at %08x\n", dir->entry, dir->cluster, directory_entry.first_cluster);
+    fatx_debug(fs, "dirent %zd of cluster %zd data starts at %08x\n", dir->entry, dir->cluster, fatx_from_disk_u32(fs, directory_entry.first_cluster));
 
     /* Copy filename. */
     memcpy(entry->filename, directory_entry.filename, directory_entry.filename_len);
@@ -280,14 +280,14 @@ int fatx_write_dir(struct fatx_fs *fs, struct fatx_dir *dir, struct fatx_dirent 
     fatx_debug(fs, "\tfilename_len: \t0x%x\n", directory_entry.filename_len);
     fatx_debug(fs, "\tattributes: \t0x%x\n", directory_entry.attributes);
     fatx_debug(fs, "\tfilename: \t%s\n", entry->filename);
-    fatx_debug(fs, "\tfirst_cluster: \t0x%x\n", directory_entry.first_cluster);
-    fatx_debug(fs, "\tfile_size: \t0x%x\n", directory_entry.file_size);
-    fatx_debug(fs, "\tmodified_time: \t0x%x\n", directory_entry.modified_time);
-    fatx_debug(fs, "\tmodified_date: \t0x%x\n", directory_entry.modified_date);
-    fatx_debug(fs, "\tcreated_time: \t0x%x\n", directory_entry.created_time);
-    fatx_debug(fs, "\tcreated_date: \t0x%x\n", directory_entry.created_date);
-    fatx_debug(fs, "\taccessed_time: \t0x%x\n", directory_entry.accessed_time);
-    fatx_debug(fs, "\taccessed_date: \t0x%x\n", directory_entry.accessed_date);
+    fatx_debug(fs, "\tfirst_cluster: \t0x%x\n", fatx_from_disk_u32(fs, directory_entry.first_cluster));
+    fatx_debug(fs, "\tfile_size: \t0x%x\n", fatx_from_disk_u32(fs, directory_entry.file_size));
+    fatx_debug(fs, "\tmodified_time: \t0x%x\n", fatx_from_disk_u16(fs, directory_entry.modified_time));
+    fatx_debug(fs, "\tmodified_date: \t0x%x\n", fatx_from_disk_u16(fs, directory_entry.modified_date));
+    fatx_debug(fs, "\tcreated_time: \t0x%x\n", fatx_from_disk_u16(fs, directory_entry.created_time));
+    fatx_debug(fs, "\tcreated_date: \t0x%x\n", fatx_from_disk_u16(fs, directory_entry.created_date));
+    fatx_debug(fs, "\taccessed_time: \t0x%x\n", fatx_from_disk_u16(fs, directory_entry.accessed_time));
+    fatx_debug(fs, "\taccessed_date: \t0x%x\n", fatx_from_disk_u16(fs, directory_entry.accessed_date));
     fatx_debug(fs, "}\n");
 
     /* Write out the raw directory entry. */

--- a/libfatx/fatx_dir.c
+++ b/libfatx/fatx_dir.c
@@ -267,6 +267,7 @@ int fatx_write_dir(struct fatx_fs *fs, struct fatx_dir *dir, struct fatx_dirent 
 
     /* Construct the raw directory entry */
     size_t filename_len = strlen(entry->filename);
+    memset(&directory_entry, 0xFF, sizeof(directory_entry));
     memcpy(directory_entry.filename, entry->filename, filename_len);
 
     status = fatx_attr_to_dirent(fs, attr, &directory_entry);

--- a/libfatx/fatx_disk.c
+++ b/libfatx/fatx_disk.c
@@ -34,6 +34,55 @@ struct fatx_partition_map_entry const fatx_partition_map[] = {
 };
 
 /*
+ * Xbox 360 partition map.
+ *
+ * These offsets are fixed; the 360 has no partition table on disk. Only the
+ * FATX partitions are listed. The two cache partitions that precede them
+ * (0x00080000 and 0x80080000) are not FATX and are deliberately omitted --
+ * offering them here would only produce a confusing signature failure.
+ *
+ * "data" is the user content partition and is the one nearly everybody wants.
+ * Note that 0x120eb0000, widely cited as the data partition, is in fact the
+ * backwards compatibility partition; data begins one partition later.
+ */
+struct fatx_x360_partition_map_entry const fatx_x360_partition_map[] = {
+    { .name = "sysext",  .offset = 0x10c080000, .size = 0x0ce30000 },
+    { .name = "sysext2", .offset = 0x118eb0000, .size = 0x08000000 },
+    { .name = "compat",  .offset = 0x120eb0000, .size = 0x10000000 },
+    { .name = "data",    .offset = 0x130eb0000, .size = -1         },
+};
+
+/*
+ * Given an Xbox 360 partition name, determine partition offset and size (in bytes).
+ */
+int fatx_x360_partition_to_offset_size(char const *name, uint64_t *offset, uint64_t *size)
+{
+    struct fatx_x360_partition_map_entry const *pi;
+
+    for (int i = 0; i < ARRAY_SIZE(fatx_x360_partition_map); i++)
+    {
+        pi = &fatx_x360_partition_map[i];
+
+        if (strcmp(pi->name, name) == 0)
+        {
+            *offset = pi->offset;
+            *size   = pi->size;
+            return FATX_STATUS_SUCCESS;
+        }
+    }
+
+    return FATX_STATUS_ERROR;
+}
+
+/*
+ * The list of valid Xbox 360 partition names, for help and error messages.
+ */
+char const *fatx_x360_partition_names(void)
+{
+    return "sysext, sysext2, compat, data";
+}
+
+/*
  * Given a drive letter, determine partition offset and size (in bytes).
  */
 int fatx_drive_to_offset_size(char drive_letter, uint64_t *offset, uint64_t *size)
@@ -212,6 +261,11 @@ cleanup:
 
 /*
  * Write refurb sector.
+ *
+ * The refurb info is an original Xbox structure living at a fixed offset on the
+ * physical disk, outside any partition, and has no Xbox 360 equivalent. It is
+ * therefore always written little-endian: this function operates on a path
+ * rather than an opened filesystem, so no variant is in scope to swap against.
  */
 int fatx_disk_write_refurb_info(char const *path, uint32_t number_of_boots, uint64_t first_power_on)
 {

--- a/libfatx/fatx_endian.h
+++ b/libfatx/fatx_endian.h
@@ -1,0 +1,137 @@
+/*
+ * FATX Filesystem Library
+ *
+ * Copyright (C) 2015  Matt Borgerson
+ * Copyright (C) 2026  Mijael Viricochea
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FATX_ENDIAN_H
+#define FATX_ENDIAN_H
+
+#include <stdint.h>
+
+#include "fatx.h"
+
+/*
+ * On-disk byte order.
+ *
+ * The original Xbox stores all multi-byte on-disk values little-endian; the
+ * Xbox 360 stores the same structures big-endian. Every multi-byte value that
+ * comes from, or is going to, the disk must pass through one of the helpers
+ * below. Raw file data must NOT: it is a byte stream and has no byte order.
+ *
+ * The conversion is symmetric, so from_disk and to_disk are the same operation.
+ * They exist as separate names purely so call sites document their direction.
+ */
+
+/* Byte order of the host we were compiled for. */
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define FATX_HOST_BIG_ENDIAN 1
+#else
+#define FATX_HOST_BIG_ENDIAN 0
+#endif
+
+#if defined(_MSC_VER)
+#include <stdlib.h>
+#define FATX_BSWAP16(v) _byteswap_ushort(v)
+#define FATX_BSWAP32(v) _byteswap_ulong(v)
+#define FATX_BSWAP64(v) _byteswap_uint64(v)
+#else
+#define FATX_BSWAP16(v) __builtin_bswap16(v)
+#define FATX_BSWAP32(v) __builtin_bswap32(v)
+#define FATX_BSWAP64(v) __builtin_bswap64(v)
+#endif
+
+/*
+ * True when the on-disk byte order differs from the host's, i.e. when values
+ * crossing the disk boundary have to be swapped.
+ */
+static inline int fatx_endian_swap_required(struct fatx_fs const *fs)
+{
+    int disk_is_big_endian = (fs->variant == FATX_VARIANT_X360);
+    return disk_is_big_endian != FATX_HOST_BIG_ENDIAN;
+}
+
+static inline uint16_t fatx_from_disk_u16(struct fatx_fs const *fs, uint16_t value)
+{
+    return fatx_endian_swap_required(fs) ? FATX_BSWAP16(value) : value;
+}
+
+static inline uint32_t fatx_from_disk_u32(struct fatx_fs const *fs, uint32_t value)
+{
+    return fatx_endian_swap_required(fs) ? FATX_BSWAP32(value) : value;
+}
+
+static inline uint64_t fatx_from_disk_u64(struct fatx_fs const *fs, uint64_t value)
+{
+    return fatx_endian_swap_required(fs) ? FATX_BSWAP64(value) : value;
+}
+
+static inline uint16_t fatx_to_disk_u16(struct fatx_fs const *fs, uint16_t value)
+{
+    return fatx_from_disk_u16(fs, value);
+}
+
+static inline uint32_t fatx_to_disk_u32(struct fatx_fs const *fs, uint32_t value)
+{
+    return fatx_from_disk_u32(fs, value);
+}
+
+static inline uint64_t fatx_to_disk_u64(struct fatx_fs const *fs, uint64_t value)
+{
+    return fatx_from_disk_u64(fs, value);
+}
+
+/*
+ * Identify the variant from a raw, unswapped signature word.
+ *
+ * The signature is byte-identical in both variants: the original Xbox writes
+ * the bytes 'F','A','T','X' and reads them little-endian, the Xbox 360 writes
+ * 'X','T','A','F' and reads them big-endian, and both yield FATX_SIGNATURE.
+ * So whichever way round the raw word matches tells us the disk's byte order.
+ *
+ * Returns FATX_VARIANT_AUTO if the word is not a FATX signature either way.
+ */
+static inline enum fatx_variant fatx_variant_from_raw_signature(uint32_t raw,
+                                                                uint32_t signature)
+{
+    if (raw == signature)
+    {
+        /* Disk byte order matches the host's. */
+        return FATX_HOST_BIG_ENDIAN ? FATX_VARIANT_X360 : FATX_VARIANT_XBOX;
+    }
+
+    if (FATX_BSWAP32(raw) == signature)
+    {
+        /* Disk byte order is the opposite of the host's. */
+        return FATX_HOST_BIG_ENDIAN ? FATX_VARIANT_XBOX : FATX_VARIANT_X360;
+    }
+
+    return FATX_VARIANT_AUTO;
+}
+
+static inline char const *fatx_variant_name(enum fatx_variant variant)
+{
+    switch (variant)
+    {
+        case FATX_VARIANT_XBOX: return "xbox";
+        case FATX_VARIANT_X360: return "x360";
+        default:                return "auto";
+    }
+}
+
+#endif

--- a/libfatx/fatx_fat.c
+++ b/libfatx/fatx_fat.c
@@ -212,13 +212,20 @@ int fatx_read_fat(struct fatx_fs *fs, size_t index, fatx_fat_entry *entry)
         }
     }
 
+    /*
+     * The cache holds the FAT window in on-disk byte order, so entries are
+     * swapped here on the way in and out rather than at cache fill/flush time:
+     * the flush rewrites the whole window including entries that were never
+     * touched, so a fill-time swap would have to be exactly inverted on every
+     * flush path, including the early-out when the cache is not dirty.
+     */
     if (fs->fat_type == FATX_FAT_TYPE_16)
     {
-        *entry = ((uint16_t*) cache->data)[index - cache->position];
+        *entry = fatx_from_disk_u16(fs, ((uint16_t*) cache->data)[index - cache->position]);
     }
     else
     {
-        *entry = ((uint32_t*) cache->data)[index - cache->position];
+        *entry = fatx_from_disk_u32(fs, ((uint32_t*) cache->data)[index - cache->position]);
     }
 
     return FATX_STATUS_SUCCESS;
@@ -251,11 +258,11 @@ int fatx_write_fat(struct fatx_fs *fs, size_t index, fatx_fat_entry entry)
 
     if (fs->fat_type == FATX_FAT_TYPE_16)
     {
-        ((uint16_t*) cache->data)[index - cache->position] = entry;
+        ((uint16_t*) cache->data)[index - cache->position] = fatx_to_disk_u16(fs, entry);
     }
     else
     {
-        ((uint32_t*) cache->data)[index - cache->position] = entry;
+        ((uint32_t*) cache->data)[index - cache->position] = fatx_to_disk_u32(fs, entry);
     }
 
     cache->dirty = true;

--- a/libfatx/fatx_internal.h
+++ b/libfatx/fatx_internal.h
@@ -21,6 +21,7 @@
 #define FATX_INTERNAL_H
 
 #include "fatx.h"
+#include "fatx_endian.h"
 
 /* FATX refurb info signature ('RFRB') */
 #define FATX_REFURB_SIGNATURE        0x42524652

--- a/libfatx/fatx_internal.h
+++ b/libfatx/fatx_internal.h
@@ -53,18 +53,37 @@
 /* Mask to be applied when reading directory entry attributes. */
 #define FATX_ATTR_MASK               0x0f
 
-/* The epoch. */
+/*
+ * The epoch.
+ *
+ * The original Xbox counts years from 2000. The Xbox 360 uses the standard FAT
+ * epoch of 1980, confirmed against a retail disk: its factory-written files are
+ * stamped 2005-11-22, the console's launch date, which only decodes correctly
+ * with a 1980 base.
+ */
 #define FATX_EPOCH                   2000
+#define FATX_X360_EPOCH              1980
 
-/* Macros to unpack date/time values. */
+/*
+ * Macros to unpack date/time values.
+ *
+ * The date layout is common to both consoles. The time layout is not: the
+ * original Xbox packs the hour in 4 bits and the minute in 5, while the 360
+ * uses the standard FAT widths of 5 and 6. A retail 360 disk carries hours of
+ * 21 and 23 and minutes of 50 and 59, none of which fit the narrower fields.
+ */
 #define FATX_TIME_TO_HOUR(t)         (((t)>>11)&0xf)
 #define FATX_TIME_TO_MINUTE(t)       (((t)>>5)&0x1f)
 #define FATX_TIME_TO_SECOND(t)       (((t)&0x1f)*2)
-#define FATX_DATE_TO_YEAR(d)         ((((d)>>9)&0x7f)+FATX_EPOCH)
+#define FATX_DATE_TO_YEAR(d, e)      ((((d)>>9)&0x7f)+(e))
 #define FATX_DATE_TO_MONTH(d)        (((d)>>5)&0xf)
 #define FATX_DATE_TO_DAY(d)          ((d)&0x1f)
-#define FATX_DATE(d, m, y)           ((d&0x1f) | ((m&0xf) << 5) | (((y - FATX_EPOCH)&0x7f) << 9))
+#define FATX_DATE(d, m, y, e)        ((d&0x1f) | ((m&0xf) << 5) | (((y - (e))&0x7f) << 9))
 #define FATX_TIME(h, m, s)           (((h&0xf) << 11) | ((m&0x1f) << 5) | ((s / 2)&0x1f))
+
+#define FATX_X360_TIME_TO_HOUR(t)    (((t)>>11)&0x1f)
+#define FATX_X360_TIME_TO_MINUTE(t)  (((t)>>5)&0x3f)
+#define FATX_X360_TIME(h, m, s)      (((h&0x1f) << 11) | ((m&0x3f) << 5) | ((s / 2)&0x1f))
 
 /* Default seperator. */
 #define FATX_PATH_SEPERATOR          '/'
@@ -114,6 +133,16 @@ _Static_assert(sizeof(struct fatx_superblock) == 4096, "fatx_superblock struct *
 /*
  * The directory entry as it appears on disk.
  */
+/*
+ * NOTE: the two halves of each timestamp are stored in the opposite order on
+ * the two consoles. The original Xbox writes the time first and then the date,
+ * as the member names say; the Xbox 360 writes the date first and then the
+ * time. Confirmed against a retail 360 disk, where reading the pair in the
+ * original Xbox's order yields impossible calendar dates for a fifth of the
+ * entries. Always go through fatx_dirent_to_attr/fatx_attr_to_dirent, which
+ * resolve the order from the variant, rather than reading these members
+ * directly.
+ */
 #pragma pack(1)
 struct fatx_raw_directory_entry {
     uint8_t  filename_len;
@@ -121,8 +150,8 @@ struct fatx_raw_directory_entry {
     char     filename[FATX_MAX_FILENAME_LEN];
     uint32_t first_cluster;
     uint32_t file_size;
-    uint16_t modified_time;
-    uint16_t modified_date;
+    uint16_t modified_time; /* date, on the Xbox 360 */
+    uint16_t modified_date; /* time, on the Xbox 360 */
     uint16_t created_time;
     uint16_t created_date;
     uint16_t accessed_time;
@@ -167,9 +196,9 @@ int fatx_mark_end_of_dir(struct fatx_fs *fs, struct fatx_dir *dir);
 
 /* Misc Functions */
 int fatx_get_path_component(char const *path, size_t component, char const **start, size_t *len);
-int fatx_unpack_date(uint16_t in, struct fatx_ts *out);
-int fatx_unpack_time(uint16_t in, struct fatx_ts *out);
-int fatx_pack_date(struct fatx_ts *in, uint16_t *out);
-int fatx_pack_time(struct fatx_ts *in, uint16_t *out);
+int fatx_unpack_date(struct fatx_fs *fs, uint16_t in, struct fatx_ts *out);
+int fatx_unpack_time(struct fatx_fs *fs, uint16_t in, struct fatx_ts *out);
+int fatx_pack_date(struct fatx_fs *fs, struct fatx_ts *in, uint16_t *out);
+int fatx_pack_time(struct fatx_fs *fs, struct fatx_ts *in, uint16_t *out);
 
 #endif

--- a/libfatx/fatx_misc.c
+++ b/libfatx/fatx_misc.c
@@ -131,20 +131,28 @@ char *fatx_basename(const char *path)
 }
 
 /*
+ * The year the timestamps of this filesystem count from.
+ */
+static int fatx_epoch(struct fatx_fs *fs)
+{
+    return fs->variant == FATX_VARIANT_X360 ? FATX_X360_EPOCH : FATX_EPOCH;
+}
+
+/*
  * Pack a FATX date.
  */
-int fatx_pack_date(struct fatx_ts *in, uint16_t *out)
+int fatx_pack_date(struct fatx_fs *fs, struct fatx_ts *in, uint16_t *out)
 {
-    *out = FATX_DATE(in->day, in->month, in->year);;
+    *out = FATX_DATE(in->day, in->month, in->year, fatx_epoch(fs));
     return FATX_STATUS_SUCCESS;
 }
 
 /*
  * Unpack a FATX date.
  */
-int fatx_unpack_date(uint16_t in, struct fatx_ts *out)
+int fatx_unpack_date(struct fatx_fs *fs, uint16_t in, struct fatx_ts *out)
 {
-    out->year  = FATX_DATE_TO_YEAR(in);
+    out->year  = FATX_DATE_TO_YEAR(in, fatx_epoch(fs));
     out->month = FATX_DATE_TO_MONTH(in);
     out->day   = FATX_DATE_TO_DAY(in);
     return FATX_STATUS_SUCCESS;
@@ -153,19 +161,34 @@ int fatx_unpack_date(uint16_t in, struct fatx_ts *out)
 /*
  * Pack a FATX time.
  */
-int fatx_pack_time(struct fatx_ts *in, uint16_t *out)
+int fatx_pack_time(struct fatx_fs *fs, struct fatx_ts *in, uint16_t *out)
 {
-    *out = FATX_TIME(in->hour, in->minute, in->second);;
+    if (fs->variant == FATX_VARIANT_X360)
+    {
+        *out = FATX_X360_TIME(in->hour, in->minute, in->second);
+    }
+    else
+    {
+        *out = FATX_TIME(in->hour, in->minute, in->second);
+    }
     return FATX_STATUS_SUCCESS;
 }
 
 /*
  * Unpack a FATX time.
  */
-int fatx_unpack_time(uint16_t in, struct fatx_ts *out)
+int fatx_unpack_time(struct fatx_fs *fs, uint16_t in, struct fatx_ts *out)
 {
-    out->hour   = FATX_TIME_TO_HOUR(in);
-    out->minute = FATX_TIME_TO_MINUTE(in);
+    if (fs->variant == FATX_VARIANT_X360)
+    {
+        out->hour   = FATX_X360_TIME_TO_HOUR(in);
+        out->minute = FATX_X360_TIME_TO_MINUTE(in);
+    }
+    else
+    {
+        out->hour   = FATX_TIME_TO_HOUR(in);
+        out->minute = FATX_TIME_TO_MINUTE(in);
+    }
     out->second = FATX_TIME_TO_SECOND(in);
     return FATX_STATUS_SUCCESS;
 }
@@ -188,12 +211,21 @@ time_t fatx_ts_to_time_t(const struct fatx_ts *in)
 {
     struct tm t;
 
+    memset(&t, 0, sizeof(t));
+
     t.tm_sec  = in->second;
     t.tm_min  = in->minute;
     t.tm_hour = in->hour;
     t.tm_mday = in->day;
     t.tm_mon  = in->month - 1;
     t.tm_year = in->year-1900;
+
+    /*
+     * FATX timestamps are local wall-clock time with no DST flag of their own,
+     * so let mktime work out whether daylight saving was in effect. Leaving
+     * tm_isdst indeterminate shifts timestamps by an hour.
+     */
+    t.tm_isdst = -1;
 
     return mktime(&t);
 }

--- a/libfatx/fatx_partition.c
+++ b/libfatx/fatx_partition.c
@@ -25,6 +25,10 @@
 
 /*
  * Check partition signature.
+ *
+ * When the variant is FATX_VARIANT_AUTO this also determines it: the raw
+ * signature word identifies the on-disk byte order, so a successful check
+ * leaves fs->variant resolved to a concrete variant.
  */
 int fatx_check_partition_signature(struct fatx_fs *fs)
 {
@@ -42,9 +46,26 @@ int fatx_check_partition_signature(struct fatx_fs *fs)
         return FATX_STATUS_ERROR;
     }
 
-    if (signature != FATX_SIGNATURE)
+    if (fs->variant == FATX_VARIANT_AUTO)
     {
-        fatx_error(fs, "invalid signature\n");
+        enum fatx_variant detected;
+
+        detected = fatx_variant_from_raw_signature(signature, FATX_SIGNATURE);
+        if (detected == FATX_VARIANT_AUTO)
+        {
+            fatx_error(fs, "invalid signature (got %.8x, expected %.8x in either byte order)\n",
+                       signature, FATX_SIGNATURE);
+            return FATX_STATUS_ERROR;
+        }
+
+        fs->variant = detected;
+        fatx_info(fs, "detected %s filesystem\n", fatx_variant_name(fs->variant));
+        return FATX_STATUS_SUCCESS;
+    }
+
+    if (fatx_from_disk_u32(fs, signature) != FATX_SIGNATURE)
+    {
+        fatx_error(fs, "invalid signature for %s filesystem\n", fatx_variant_name(fs->variant));
         return FATX_STATUS_ERROR;
     }
 
@@ -72,6 +93,23 @@ int fatx_init_superblock(struct fatx_fs *fs, size_t sectors_per_cluster)
     /* Initialize device with a new FATX superblock. */
     else
     {
+        /*
+         * There is no signature to probe when formatting. Formatting a 360
+         * partition is not supported yet, so an unresolved variant means the
+         * original Xbox.
+         */
+        if (fs->variant == FATX_VARIANT_AUTO)
+        {
+            fs->variant = FATX_VARIANT_XBOX;
+        }
+
+        if (fs->variant != FATX_VARIANT_XBOX)
+        {
+            fatx_error(fs, "formatting a %s filesystem is not supported\n",
+                       fatx_variant_name(fs->variant));
+            return FATX_STATUS_ERROR;
+        }
+
 #ifdef _WIN32
         fs->volume_id = 12345678;
 #else
@@ -104,15 +142,15 @@ int fatx_read_superblock(struct fatx_fs *fs)
         return FATX_STATUS_ERROR;
     }
 
-    if (superblock.signature != FATX_SIGNATURE)
+    if (fatx_from_disk_u32(fs, superblock.signature) != FATX_SIGNATURE)
     {
         fatx_error(fs, "invalid signature\n");
         return FATX_STATUS_ERROR;
     }
 
-    fs->volume_id = superblock.volume_id;
-    fs->sectors_per_cluster = superblock.sectors_per_cluster;
-    fs->root_cluster = superblock.root_cluster;
+    fs->volume_id = fatx_from_disk_u32(fs, superblock.volume_id);
+    fs->sectors_per_cluster = fatx_from_disk_u32(fs, superblock.sectors_per_cluster);
+    fs->root_cluster = fatx_from_disk_u32(fs, superblock.root_cluster);
 
     return FATX_STATUS_SUCCESS;
 }
@@ -132,11 +170,11 @@ int fatx_write_superblock(struct fatx_fs *fs)
 
     memset(&superblock, 0xFF, sizeof(struct fatx_superblock));
 
-    superblock.signature = FATX_SIGNATURE;
-    superblock.sectors_per_cluster = fs->sectors_per_cluster;
-    superblock.volume_id = fs->volume_id;
-    superblock.root_cluster = fs->root_cluster;
-    superblock.unknown1 = 0;
+    superblock.signature = fatx_to_disk_u32(fs, FATX_SIGNATURE);
+    superblock.sectors_per_cluster = fatx_to_disk_u32(fs, fs->sectors_per_cluster);
+    superblock.volume_id = fatx_to_disk_u32(fs, fs->volume_id);
+    superblock.root_cluster = fatx_to_disk_u32(fs, fs->root_cluster);
+    superblock.unknown1 = fatx_to_disk_u16(fs, 0);
 
     if (fatx_dev_write(fs, &superblock, sizeof(struct fatx_superblock), 1) != 1)
     {

--- a/pyfatx/build_cffi.py
+++ b/pyfatx/build_cffi.py
@@ -101,7 +101,12 @@ def ffibuilder():
 
         struct fatx_fs *pyfatx_open_helper(void);
 
+        enum fatx_variant { FATX_VARIANT_AUTO, FATX_VARIANT_XBOX, FATX_VARIANT_X360 };
+
+        #define FATX_OPEN_READ_ONLY ...
+
         int fatx_open_device(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster);
+        int fatx_open_device_ex(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster, enum fatx_variant variant, unsigned int flags);
         int fatx_close_device(struct fatx_fs *fs);
         int fatx_open_dir(struct fatx_fs *fs, char const *path, struct fatx_dir *dir);
         int fatx_read_dir(struct fatx_fs *fs, struct fatx_dir *dir, struct fatx_dirent *entry, struct fatx_attr *attr, struct fatx_dirent **result);
@@ -126,6 +131,7 @@ def ffibuilder():
         int fatx_disk_format(struct fatx_fs *fs, char const *path, size_t sector_size, enum fatx_format format_type, size_t sectors_per_cluster);
         int fatx_disk_format_partition(struct fatx_fs *fs, char const *path, uint64_t offset, uint64_t size, size_t sector_size, size_t sectors_per_cluster);
         int fatx_drive_to_offset_size(char drive_letter, uint64_t *offset, uint64_t *size);
+        int fatx_x360_partition_to_offset_size(char const *name, uint64_t *offset, uint64_t *size);
         int fatx_disk_write_refurb_info(char const *path, uint32_t number_of_boots, uint64_t first_power_on);
         """)
     return ffi

--- a/pyfatx/pyfatx/__init__.py
+++ b/pyfatx/pyfatx/__init__.py
@@ -56,22 +56,61 @@ class Fatx:
 	FATX Filesystem Interface
 	"""
 
+	#: Original Xbox partitions, by drive letter.
+	XBOX_PARTITIONS = {
+		'x': (0x00080000, 0x02ee00000),
+		'y': (0x2ee80000, 0x02ee00000),
+		'z': (0x5dc80000, 0x02ee00000),
+		'c': (0x8ca80000, 0x01f400000),
+		'e': (0xabe80000, 0x1312d6000),
+	}
+
+	#: Xbox 360 partitions. The 360 has no drive letters, and no partition
+	#: table either -- these offsets are fixed. 'data' is the user content
+	#: partition and runs to the end of the disk.
+	X360_PARTITIONS = {
+		'sysext':  (0x10c080000, 0x0ce30000),
+		'sysext2': (0x118eb0000, 0x08000000),
+		'compat':  (0x120eb0000, 0x10000000),
+		'data':    (0x130eb0000, 0xffffffffffffffff),
+	}
+
+	VARIANTS = {
+		'auto': FATX_VARIANT_AUTO,
+		'xbox': FATX_VARIANT_XBOX,
+		'x360': FATX_VARIANT_X360,
+	}
+
 	def __init__(self, path: str, offset: Optional[int] = None, size: Optional[int] = None, drive: str = 'c',
-		         sector_size: int = 512):
+		         sector_size: int = 512, variant: str = 'auto', partition: Optional[str] = None,
+		         read_only: bool = False):
+		"""
+		Open a FATX filesystem.
+
+		variant selects the on-disk byte order: 'auto' (default) detects it
+		from the partition signature, 'xbox' is the original Xbox and 'x360'
+		is the big-endian Xbox 360 layout.
+
+		partition names an Xbox 360 partition (see X360_PARTITIONS) and is an
+		alternative to drive, which names an original Xbox one.
+		"""
 		self.fs = pyfatx_open_helper()
 		assert self.fs
-		if offset is None:
-			partitions = {
-				'x': (0x00080000, 0x02ee00000),
-				'y': (0x2ee80000, 0x02ee00000),
-				'z': (0x5dc80000, 0x02ee00000),
-				'c': (0x8ca80000, 0x01f400000),
-				'e': (0xabe80000, 0x1312d6000),
-			}
-			offset, size = partitions[drive]
+
+		if variant not in self.VARIANTS:
+			raise ValueError(f'unknown variant {variant!r}, expected one of {sorted(self.VARIANTS)}')
+		if partition is not None and offset is None:
+			if partition not in self.X360_PARTITIONS:
+				raise ValueError(f'unknown partition {partition!r}, expected one of {sorted(self.X360_PARTITIONS)}')
+			offset, size = self.X360_PARTITIONS[partition]
+		elif offset is None:
+			offset, size = self.XBOX_PARTITIONS[drive]
+
 		if isinstance(path, str):
 			path = path.encode('utf-8')
-		s = fatx_open_device(self.fs, path, offset, size, sector_size, 0)
+		flags = FATX_OPEN_READ_ONLY if read_only else 0
+		s = fatx_open_device_ex(self.fs, path, offset, size, sector_size, 0,
+		                        self.VARIANTS[variant], flags)
 		if s != 0:
 			self.fs = None
 		assert s == 0

--- a/pyfatx/pyfatx/__main__.py
+++ b/pyfatx/pyfatx/__main__.py
@@ -12,7 +12,13 @@ logging.basicConfig(level=logging.INFO)
 
 def main():
 	ap = argparse.ArgumentParser(description='FATX Filesystem Utility')
-	ap.add_argument('--drive', '-d', default='c', help='Drive letter (default: c)')
+	ap.add_argument('--drive', '-d', default='c', help='Original Xbox drive letter (default: c)')
+	ap.add_argument('--variant', default='auto', choices=['auto', 'xbox', 'x360'],
+	                help='On-disk byte order (default: auto-detect from the partition signature)')
+	ap.add_argument('--partition', default=None, choices=sorted(Fatx.X360_PARTITIONS),
+	                help='Xbox 360 partition to open, by name')
+	ap.add_argument('--read-only', action='store_true',
+	                help='Open the device without write access at all')
 	ap.add_argument('--offset', type=int, default=None, help='Partition offset')
 	ap.add_argument('--size', type=int, default=None, help='Partition size')
 	ap.add_argument('--sector-size', type=int, default=512, help='Drive sector size (default: 512)')
@@ -34,7 +40,14 @@ def main():
 		print(f'Formatting {args.device}')
 		Fatx.format(args.device)
 
-	fs = Fatx(args.device, offset=args.offset, size=args.size, drive=args.drive, sector_size=args.sector_size)
+	partition = args.partition
+	if partition is None and args.variant == 'x360' and args.offset is None:
+		# An Xbox 360 disk has no drive letters, so default to user content.
+		partition = 'data'
+
+	fs = Fatx(args.device, offset=args.offset, size=args.size, drive=args.drive,
+	          sector_size=args.sector_size, variant=args.variant, partition=partition,
+	          read_only=args.read_only)
 	if args.list:
 		for dirpath, dirnames, filenames in fs.walk('/'):
 			for f in filenames:

--- a/pyfatx/tests/test.py
+++ b/pyfatx/tests/test.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 import functools
+import importlib.util
 import os
 import tempfile
 import unittest
 import random
 
 from pyfatx import Fatx
+
+X360_IMAGE_BUILDER = os.path.join(
+	os.path.dirname(os.path.abspath(__file__)), '..', '..', 'tests', 'make_x360_image.py')
 
 
 def with_formatted_disk(func):
@@ -448,3 +452,86 @@ class BasicTest(unittest.TestCase):
 
 if __name__ == '__main__':
 	unittest.main()
+
+
+def with_x360_disk(func):
+	"""
+	Provide a synthetic big-endian (Xbox 360) FATX image.
+
+	Built by tests/make_x360_image.py, which assembles the on-disk structures
+	from the format spec rather than with libfatx's own writer -- so a field
+	that is never byte-swapped cannot cancel itself out between the writer and
+	the reader and slip through.
+	"""
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		spec = importlib.util.spec_from_file_location('make_x360_image', X360_IMAGE_BUILDER)
+		builder = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(builder)
+
+		image, contents = builder.build()
+		with tempfile.NamedTemporaryFile(delete=False, suffix='-x360') as tmp_file:
+			tmp_file.write(image)
+			path = tmp_file.name
+		try:
+			return func(*args, path, contents, **kwargs)
+		finally:
+			os.remove(path)
+	return wrapper
+
+
+class X360Test(unittest.TestCase):
+	"""
+	Xbox 360 (big-endian) filesystem tests.
+	"""
+
+	IMAGE_SIZE = 16 * 1024 * 1024
+
+	def _open(self, path, **kwargs):
+		kwargs.setdefault('offset', 0)
+		kwargs.setdefault('size', self.IMAGE_SIZE)
+		kwargs.setdefault('read_only', True)
+		return Fatx(path, **kwargs)
+
+	def _names(self, fs, path):
+		return sorted(a.filename for a in fs.listdir(path))
+
+	@with_x360_disk
+	def test_variant_is_autodetected(self, path, contents):
+		# No variant given: the signature alone has to identify the byte order.
+		fs = self._open(path)
+		self.assertEqual(self._names(fs, '/'), ['GAMES', 'HELLO.TXT'])
+
+	@with_x360_disk
+	def test_explicit_variant(self, path, contents):
+		fs = self._open(path, variant='x360')
+		self.assertEqual(self._names(fs, '/'), ['GAMES', 'HELLO.TXT'])
+
+	@with_x360_disk
+	def test_wrong_variant_is_rejected(self, path, contents):
+		# Must fail loudly rather than silently misparse the metadata.
+		with self.assertRaises(AssertionError):
+			self._open(path, variant='xbox')
+
+	@with_x360_disk
+	def test_file_sizes(self, path, contents):
+		fs = self._open(path)
+		for filename, data in contents.items():
+			self.assertEqual(fs.get_attr(filename).file_size, len(data), filename)
+
+	@with_x360_disk
+	def test_file_contents(self, path, contents):
+		fs = self._open(path)
+		for filename, data in contents.items():
+			self.assertEqual(fs.read(filename), data, filename)
+
+	@with_x360_disk
+	def test_subdirectory(self, path, contents):
+		fs = self._open(path)
+		self.assertEqual(self._names(fs, '/GAMES'), ['COVER.JPG'])
+
+	@with_x360_disk
+	def test_read_only_refuses_writes(self, path, contents):
+		fs = self._open(path, read_only=True)
+		with self.assertRaises(AssertionError):
+			fs.mkdir('/SHOULD_NOT_APPEAR')

--- a/rust/fatx-fuse/src/main.rs
+++ b/rust/fatx-fuse/src/main.rs
@@ -53,6 +53,7 @@ impl InodeTracker {
 }
 
 struct FuseFatxFs {
+    variant: fatx::Variant,
     fatx: FatxFsHandle,
     inodes: InodeTracker,
 }
@@ -85,10 +86,10 @@ impl FuseFatxFs {
                 ino: inode,
                 size: 0,
                 blocks: 0,
-                atime: fatx_datetime_to_systemtime(dirent.accessed()),
-                mtime: fatx_datetime_to_systemtime(dirent.modified()),
-                ctime: fatx_datetime_to_systemtime(dirent.modified()),
-                crtime: fatx_datetime_to_systemtime(dirent.created()),
+                atime: fatx_datetime_to_systemtime(dirent.accessed(self.variant)),
+                mtime: fatx_datetime_to_systemtime(dirent.modified(self.variant)),
+                ctime: fatx_datetime_to_systemtime(dirent.modified(self.variant)),
+                crtime: fatx_datetime_to_systemtime(dirent.created(self.variant)),
                 kind: FileType::Directory,
                 perm: 0o755,
                 nlink: 2,
@@ -105,10 +106,10 @@ impl FuseFatxFs {
                 ino: inode,
                 size: dirent.file_size() as u64,
                 blocks: (dirent.file_size() / 512) as u64, // FIXME: num clusters?
-                atime: fatx_datetime_to_systemtime(dirent.accessed()),
-                mtime: fatx_datetime_to_systemtime(dirent.modified()),
-                ctime: fatx_datetime_to_systemtime(dirent.modified()),
-                crtime: fatx_datetime_to_systemtime(dirent.created()),
+                atime: fatx_datetime_to_systemtime(dirent.accessed(self.variant)),
+                mtime: fatx_datetime_to_systemtime(dirent.modified(self.variant)),
+                ctime: fatx_datetime_to_systemtime(dirent.modified(self.variant)),
+                crtime: fatx_datetime_to_systemtime(dirent.created(self.variant)),
                 kind: FileType::RegularFile,
                 perm: 0o644, // FIXME
                 nlink: 1,
@@ -274,9 +275,28 @@ struct Cli {
     #[arg()]
     mount_point: String,
 
-    /// Drive letter of c|e|x|y|z
+    /// Drive letter of c|e|x|y|z|f (original Xbox)
     #[arg(short, long, default_value_t = String::from("c"))]
     drive_letter: String,
+
+    /// On-disk byte order: auto, xbox or x360
+    #[arg(long, default_value_t = String::from("auto"))]
+    variant: String,
+
+    /// Xbox 360 partition to mount: sysext, sysext2, compat or data
+    #[arg(long)]
+    partition: Option<String>,
+
+    /// Partition offset in bytes, for images that do not start at a known one
+    #[arg(long)]
+    offset: Option<u64>,
+
+    /// Partition size in bytes. Required with --offset. Note that this is the
+    /// size of the partition on the original disk, which for a truncated dump
+    /// is not the size of the file: the FAT and cluster geometry are derived
+    /// from it, so a wrong value misplaces every data cluster.
+    #[arg(long)]
+    size: Option<u64>,
 
     /// Auto-unmount
     #[arg(long)]
@@ -298,10 +318,36 @@ fn main() {
         options.push(MountOption::AllowRoot);
     }
 
-    let config = FatxFsConfig::new(cli.device_path).drive_letter(&cli.drive_letter);
+    let variant: fatx::Variant = cli.variant.parse().unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(1);
+    });
 
+    // An Xbox 360 disk has no drive letters, so default it to user content
+    // rather than to the original Xbox's 'c'.
+    let partition = match (&cli.partition, variant) {
+        (Some(name), _) => Some(name.clone()),
+        (None, fatx::Variant::X360) => Some(String::from("data")),
+        _ => None,
+    };
+
+    let mut config = FatxFsConfig::new(cli.device_path).variant(variant);
+    config = match (cli.offset, cli.size, &partition) {
+        (Some(offset), Some(size), _) => config
+            .partition_offset_bytes(offset)
+            .partition_size_bytes(size),
+        (Some(_), None, _) | (None, Some(_), _) => {
+            eprintln!("--offset and --size must be given together");
+            std::process::exit(1);
+        }
+        (None, None, Some(name)) => config.x360_partition(name),
+        (None, None, None) => config.drive_letter(&cli.drive_letter),
+    };
+
+    let fatx = FatxFs::open_device(&config).unwrap();
     let fs = FuseFatxFs {
-        fatx: FatxFs::open_device(&config).unwrap(),
+        variant: fatx.variant(),
+        fatx,
         inodes: InodeTracker::new(),
     };
     fuser::mount2(fs, cli.mount_point, &options).unwrap();

--- a/rust/fatx/src/datetime.rs
+++ b/rust/fatx/src/datetime.rs
@@ -1,4 +1,5 @@
-const FATX_EPOCH: u16 = 2000;
+use crate::variant::Variant;
+
 pub struct Date {
     year: u16,
     /// 1 = January
@@ -7,9 +8,9 @@ pub struct Date {
 }
 
 impl Date {
-    pub fn from_fatx_encoding(encoded: u16) -> Self {
+    pub fn from_fatx_encoding(encoded: u16, variant: Variant) -> Self {
         Self {
-            year: (((encoded >> 9) & 0x7f) + FATX_EPOCH),
+            year: (((encoded >> 9) & 0x7f) + variant.epoch()),
             month: ((encoded >> 5) & 0xf) as u8,
             day: (encoded & 0x1f) as u8,
         }
@@ -34,10 +35,17 @@ pub struct Time {
 }
 
 impl Time {
-    pub fn from_fatx_encoding(encoded: u16) -> Self {
+    /// The Xbox 360 uses the standard FAT field widths, 5 bits of hour and 6
+    /// of minute. The original Xbox uses 4 and 5, which cannot represent an
+    /// hour past 15 or a minute past 31.
+    pub fn from_fatx_encoding(encoded: u16, variant: Variant) -> Self {
+        let (hour_mask, minute_mask) = match variant {
+            Variant::X360 => (0x1f, 0x3f),
+            _ => (0xf, 0x1f),
+        };
         Self {
-            hour: ((encoded >> 11) & 0xf) as u8,
-            minute: ((encoded >> 5) & 0x1f) as u8,
+            hour: ((encoded >> 11) & hour_mask) as u8,
+            minute: ((encoded >> 5) & minute_mask) as u8,
             second: ((encoded & 0x1f) * 2) as u8,
         }
     }
@@ -59,10 +67,10 @@ pub struct DateTime {
 }
 
 impl DateTime {
-    pub fn from_fatx_encoding(date_encoded: u16, time_encoded: u16) -> Self {
+    pub fn from_fatx_encoding(date_encoded: u16, time_encoded: u16, variant: Variant) -> Self {
         Self {
-            date: Date::from_fatx_encoding(date_encoded),
-            time: Time::from_fatx_encoding(time_encoded),
+            date: Date::from_fatx_encoding(date_encoded, variant),
+            time: Time::from_fatx_encoding(time_encoded, variant),
         }
     }
 

--- a/rust/fatx/src/dir.rs
+++ b/rust/fatx/src/dir.rs
@@ -1,5 +1,7 @@
 use std::path::{Component, Path};
 
+use crate::variant::Variant;
+
 use zerocopy::byteorder::little_endian::{U16, U32};
 use zerocopy::*;
 
@@ -160,20 +162,57 @@ impl DirectoryEntry {
         self.attributes & FATX_ATTR_SYSTEM == FATX_ATTR_SYSTEM
     }
 
-    pub fn created(&self) -> DateTime {
-        DateTime::from_fatx_encoding(self.created_date.into(), self.created_time.into())
+    pub fn created(&self, variant: Variant) -> DateTime {
+        DateTime::from_fatx_encoding(self.created_date.into(), self.created_time.into(), variant)
     }
 
-    pub fn modified(&self) -> DateTime {
-        DateTime::from_fatx_encoding(self.modified_date.into(), self.modified_time.into())
+    pub fn modified(&self, variant: Variant) -> DateTime {
+        DateTime::from_fatx_encoding(
+            self.modified_date.into(),
+            self.modified_time.into(),
+            variant,
+        )
     }
 
-    pub fn accessed(&self) -> DateTime {
-        DateTime::from_fatx_encoding(self.accessed_date.into(), self.accessed_time.into())
+    pub fn accessed(&self, variant: Variant) -> DateTime {
+        DateTime::from_fatx_encoding(
+            self.accessed_date.into(),
+            self.accessed_time.into(),
+            variant,
+        )
     }
 
     pub(crate) fn first_cluster(&self) -> ClusterId {
         self.first_cluster.into()
+    }
+
+    /// Convert this entry from on-disk form into the canonical little-endian,
+    /// time-then-date layout the accessors above expect.
+    ///
+    /// Must be called on every entry read from a device. For the original Xbox
+    /// it does nothing. For the 360 it swaps each multi-byte field, and swaps
+    /// the two halves of each timestamp: the 360 stores the date first, so the
+    /// field named modified_time holds the date on that console.
+    pub(crate) fn normalize(&mut self, variant: Variant) {
+        if !variant.needs_swap() {
+            return;
+        }
+
+        self.first_cluster = u32::from(self.first_cluster).swap_bytes().into();
+        self.file_size = u32::from(self.file_size).swap_bytes().into();
+
+        // Each pair arrives as (date, time) and must end up as (time, date),
+        // with both halves byte-swapped.
+        fn swap_pair(slot0: &mut U16, slot1: &mut U16) {
+            let date = u16::from(*slot0).swap_bytes();
+            let time = u16::from(*slot1).swap_bytes();
+            *slot0 = time.into();
+            *slot1 = date.into();
+        }
+
+        swap_pair(&mut self.modified_time, &mut self.modified_date);
+        swap_pair(&mut self.created_time, &mut self.created_date);
+        swap_pair(&mut self.accessed_time, &mut self.accessed_date);
     }
 }
 
@@ -201,7 +240,7 @@ impl DirectoryEntryIterator {
 
         if (self.entry >= 0) && (self.entry as u64 >= fs.num_entries_per_cluster) {
             // Advance to next cluster
-            let fat_entry = fs.fat.entry(self.cluster);
+            let fat_entry = fs.fat.entry(self.cluster, fs.variant);
             match fat_entry {
                 Err(err) => {
                     self.finished = true;
@@ -231,7 +270,8 @@ impl DirectoryEntryIterator {
                 self.finished = true;
                 Some(Err(err.into()))
             }
-            Ok(entry) => {
+            Ok(mut entry) => {
+                entry.normalize(fs.variant);
                 if entry.kind() == DirectoryEntryKind::EndOfDirectory {
                     self.finished = true;
                 }

--- a/rust/fatx/src/fat.rs
+++ b/rust/fatx/src/fat.rs
@@ -2,6 +2,7 @@ use zerocopy::byteorder::little_endian::{U16, U32};
 use zerocopy::*;
 
 use crate::error::Error;
+use crate::variant::Variant;
 
 #[derive(Debug)]
 enum FatType {
@@ -82,7 +83,12 @@ impl Fat {
         }
     }
 
-    pub(crate) fn entry(&mut self, index: FatEntryId) -> Result<FatEntry, Error> {
+    /// Read a FAT entry.
+    ///
+    /// The cached FAT is held in on-disk byte order, so entries are swapped
+    /// here as they are read out rather than when the cache is filled.
+    pub(crate) fn entry(&mut self, index: FatEntryId, variant: Variant) -> Result<FatEntry, Error> {
+        let swap = variant.needs_swap();
         match self.fat_type {
             FatType::Type16 => {
                 let fat = <[U16]>::ref_from_bytes_with_elems(
@@ -91,6 +97,7 @@ impl Fat {
                 )
                 .unwrap();
                 let value: u16 = fat[index as usize].into();
+                let value = if swap { value.swap_bytes() } else { value };
                 Ok(value.into())
             }
             FatType::Type32 => {
@@ -100,6 +107,7 @@ impl Fat {
                 )
                 .unwrap();
                 let value: u32 = fat[index as usize].into();
+                let value = if swap { value.swap_bytes() } else { value };
                 Ok(value.into())
             }
         }

--- a/rust/fatx/src/file.rs
+++ b/rust/fatx/src/file.rs
@@ -88,10 +88,12 @@ impl io::Read for File {
 
                 // Scan through the cluster chain
                 for _ in self.cur_cluster_relative..tar_cluster_relative {
-                    self.cur_cluster_absolute = match fs.fat.entry(self.cur_cluster_absolute)? {
-                        FatEntry::Data(cluster) => cluster,
-                        _ => return Err(io::Error::other("Corrupt FAT chain")),
-                    };
+                    let variant = fs.variant;
+                    self.cur_cluster_absolute =
+                        match fs.fat.entry(self.cur_cluster_absolute, variant)? {
+                            FatEntry::Data(cluster) => cluster,
+                            _ => return Err(io::Error::other("Corrupt FAT chain")),
+                        };
                 }
                 self.cur_cluster_relative = tar_cluster_relative;
 

--- a/rust/fatx/src/fs.rs
+++ b/rust/fatx/src/fs.rs
@@ -201,7 +201,7 @@ impl FatxFs {
                 device_handle,
                 variant,
                 partition_offset_bytes: config.partition_offset_bytes,
-                partition_size_bytes: partition_size_bytes,
+                partition_size_bytes,
                 num_clusters,
                 num_bytes_per_cluster,
                 num_entries_per_cluster,

--- a/rust/fatx/src/fs.rs
+++ b/rust/fatx/src/fs.rs
@@ -7,6 +7,7 @@ use crate::error::Error;
 use crate::fat::{ClusterId, Fat};
 use crate::file::File;
 use crate::partition::{DEFAULT_PARTITION_LAYOUT, PartitionMapEntry};
+use crate::variant::Variant;
 
 use zerocopy::byteorder::little_endian::{U16, U32};
 use zerocopy::*;
@@ -27,11 +28,30 @@ pub(crate) struct Superblock {
     padding: [u8; 4078],
 }
 
+impl Superblock {
+    /// Convert from on-disk form into canonical little-endian.
+    ///
+    /// Does nothing for the original Xbox; swaps every field for the 360. The
+    /// signature is deliberately left alone: it is byte-identical in both
+    /// flavours and has already been used to work out which one this is.
+    fn normalize(&mut self, variant: Variant) {
+        if !variant.needs_swap() {
+            return;
+        }
+
+        self.volume_id = u32::from(self.volume_id).swap_bytes().into();
+        self.num_sectors_per_cluster = u32::from(self.num_sectors_per_cluster).swap_bytes().into();
+        self.root_cluster = u32::from(self.root_cluster).swap_bytes().into();
+        self.unknown_0 = u16::from(self.unknown_0).swap_bytes().into();
+    }
+}
+
 #[derive(Debug)]
 pub struct FatxFs {
     self_handle: Weak<Mutex<FatxFs>>,
 
     pub(crate) device_handle: std::fs::File,
+    pub(crate) variant: Variant,
     pub(crate) partition_offset_bytes: u64,
     pub(crate) partition_size_bytes: u64,
     pub(crate) num_clusters: u32,
@@ -47,6 +67,7 @@ pub struct FatxFsConfig {
     partition_offset_bytes: u64,
     partition_size_bytes: u64,
     num_bytes_per_sector: u64,
+    variant: Variant,
 }
 
 impl FatxFsConfig {
@@ -57,6 +78,7 @@ impl FatxFsConfig {
             partition_offset_bytes: partition.offset_bytes,
             partition_size_bytes: partition.size_bytes,
             num_bytes_per_sector: 512,
+            variant: Variant::Auto,
         }
     }
 
@@ -65,6 +87,31 @@ impl FatxFsConfig {
             PartitionMapEntry::from_letter(letter).expect("invalid partition letter");
         self.partition_offset_bytes = partition_info.offset_bytes;
         self.partition_size_bytes = partition_info.size_bytes;
+        self
+    }
+
+    /// Select an Xbox 360 partition by name.
+    pub fn x360_partition(mut self, name: &str) -> Self {
+        let partition_info =
+            PartitionMapEntry::from_x360_name(name).expect("invalid partition name");
+        self.partition_offset_bytes = partition_info.offset_bytes;
+        self.partition_size_bytes = partition_info.size_bytes;
+        self
+    }
+
+    /// Force the on-disk byte order rather than detecting it.
+    pub fn variant(mut self, variant: Variant) -> Self {
+        self.variant = variant;
+        self
+    }
+
+    pub fn partition_offset_bytes(mut self, offset: u64) -> Self {
+        self.partition_offset_bytes = offset;
+        self
+    }
+
+    pub fn partition_size_bytes(mut self, size: u64) -> Self {
+        self.partition_size_bytes = size;
         self
     }
 }
@@ -78,22 +125,46 @@ impl FatxFs {
         {
             return Err(Error::InvalidPartitionOffset);
         }
-        if !config
-            .partition_size_bytes
-            .is_multiple_of(config.num_bytes_per_sector)
-        {
+        // Open device
+        let mut device_handle = std::fs::File::open(&config.device_path)?;
+
+        // A size of u64::MAX means "the rest of the device", which is how the
+        // partitions that run to the end of the disk are described. Resolve it
+        // against the device's actual length, rounded down to a whole sector.
+        let partition_size_bytes = if config.partition_size_bytes == u64::MAX {
+            let device_size = device_handle.seek(SeekFrom::End(0))?;
+            if device_size <= config.partition_offset_bytes {
+                return Err(Error::InvalidPartitionSize);
+            }
+            let remaining = device_size - config.partition_offset_bytes;
+            remaining - (remaining % config.num_bytes_per_sector)
+        } else {
+            config.partition_size_bytes
+        };
+
+        if !partition_size_bytes.is_multiple_of(config.num_bytes_per_sector) {
             return Err(Error::InvalidPartitionSize);
         }
 
-        // Open device
-        let mut device_handle = std::fs::File::open(&config.device_path)?;
         device_handle.seek(SeekFrom::Start(config.partition_offset_bytes))?;
 
-        // Read superblock
-        let superblock = Superblock::read_from_io(&mut device_handle)?;
-        if superblock.signature != FATX_SIGNATURE {
-            return Err(Error::InvalidFilesystemSignature);
-        }
+        // Read superblock. The raw signature identifies the on-disk byte order,
+        // so checking it and resolving the variant are the same step.
+        let mut superblock = Superblock::read_from_io(&mut device_handle)?;
+        let detected = Variant::from_raw_signature(superblock.signature.into(), FATX_SIGNATURE)
+            .ok_or(Error::InvalidFilesystemSignature)?;
+        let variant = match config.variant {
+            Variant::Auto => {
+                log::info!("Detected {detected:?} filesystem");
+                detected
+            }
+            requested if requested == detected => requested,
+            requested => {
+                log::error!("Filesystem is {detected:?}, but {requested:?} was requested");
+                return Err(Error::InvalidFilesystemSignature);
+            }
+        };
+        superblock.normalize(variant);
 
         // Cluster geometry
         let num_sectors_per_cluster: u64 = superblock.num_sectors_per_cluster.into();
@@ -107,7 +178,7 @@ impl FatxFs {
 
         // Calculate FAT size
         let fat_offset_bytes = config.partition_offset_bytes + FATX_FAT_OFFSET_BYTES;
-        let num_fat_entries = (config.partition_size_bytes / num_bytes_per_cluster) as u32;
+        let num_fat_entries = (partition_size_bytes / num_bytes_per_cluster) as u32;
         if root_cluster >= num_fat_entries {
             log::error!("Root cluster of {} exceeds cluster limit", root_cluster);
             return Err(Error::InvalidRootCluster);
@@ -120,17 +191,17 @@ impl FatxFs {
 
         // Cluster geometry cont'd
         let cluster_offset_bytes = fat_offset_bytes + fat.fat_size_bytes;
-        let num_clusters =
-            ((config.partition_size_bytes - fat.fat_size_bytes - FATX_FAT_OFFSET_BYTES)
-                / num_bytes_per_cluster
-                + FATX_FAT_RESERVED_ENTRIES_COUNT as u64) as u32;
+        let num_clusters = ((partition_size_bytes - fat.fat_size_bytes - FATX_FAT_OFFSET_BYTES)
+            / num_bytes_per_cluster
+            + FATX_FAT_RESERVED_ENTRIES_COUNT as u64) as u32;
 
         let fs = Arc::new_cyclic(move |weak_self| {
             Mutex::new(FatxFs {
                 self_handle: weak_self.clone(),
                 device_handle,
+                variant,
                 partition_offset_bytes: config.partition_offset_bytes,
-                partition_size_bytes: config.partition_size_bytes,
+                partition_size_bytes: partition_size_bytes,
                 num_clusters,
                 num_bytes_per_cluster,
                 num_entries_per_cluster,
@@ -220,5 +291,11 @@ impl FatxFsHandle {
 
     pub fn read_dir(&mut self, path: &str) -> Result<DirectoryEntryIntoIterator, Error> {
         self.with_lock(|fs| fs.read_dir(path))
+    }
+
+    /// The variant this filesystem was opened as, with Auto already resolved
+    /// to whichever the signature turned out to be.
+    pub fn variant(&self) -> Variant {
+        self.with_lock(|fs| fs.variant)
     }
 }

--- a/rust/fatx/src/lib.rs
+++ b/rust/fatx/src/lib.rs
@@ -6,10 +6,12 @@ pub mod file;
 pub mod fs;
 pub mod partition;
 pub mod path;
+pub mod variant;
 
 pub use datetime::DateTime;
 pub use dir::DirectoryEntry;
 pub use error::Error;
 pub use file::File;
 pub use fs::{FatxFs, FatxFsConfig, FatxFsHandle};
-pub use partition::{DEFAULT_PARTITION_LAYOUT, PartitionMapEntry};
+pub use partition::{DEFAULT_PARTITION_LAYOUT, PartitionMapEntry, X360_PARTITION_LAYOUT};
+pub use variant::Variant;

--- a/rust/fatx/src/partition.rs
+++ b/rust/fatx/src/partition.rs
@@ -30,6 +30,44 @@ pub const DEFAULT_PARTITION_LAYOUT: &[PartitionMapEntry] = &[
         offset_bytes: 0xabe80000,
         size_bytes: 0x1312d6000,
     },
+    // Extended (non-retail) partition commonly used in homebrew. Runs to the
+    // end of the disk.
+    PartitionMapEntry {
+        letter: "f",
+        offset_bytes: 0x1dd156000,
+        size_bytes: u64::MAX,
+    },
+];
+
+/// Xbox 360 partition map.
+///
+/// The 360 has no partition table and no drive letters: partitions live at
+/// fixed offsets and are named. Only the FATX partitions are listed; the two
+/// cache partitions that precede them are not FATX.
+///
+/// Note that 0x120eb0000, widely cited as the data partition, is in fact the
+/// backwards compatibility partition. "data" is the user content partition.
+pub const X360_PARTITION_LAYOUT: &[PartitionMapEntry] = &[
+    PartitionMapEntry {
+        letter: "sysext",
+        offset_bytes: 0x10c080000,
+        size_bytes: 0x0ce30000,
+    },
+    PartitionMapEntry {
+        letter: "sysext2",
+        offset_bytes: 0x118eb0000,
+        size_bytes: 0x08000000,
+    },
+    PartitionMapEntry {
+        letter: "compat",
+        offset_bytes: 0x120eb0000,
+        size_bytes: 0x10000000,
+    },
+    PartitionMapEntry {
+        letter: "data",
+        offset_bytes: 0x130eb0000,
+        size_bytes: u64::MAX,
+    },
 ];
 
 impl PartitionMapEntry {
@@ -37,5 +75,12 @@ impl PartitionMapEntry {
         DEFAULT_PARTITION_LAYOUT
             .iter()
             .find(|&entry| entry.letter == letter)
+    }
+
+    /// Look up an Xbox 360 partition by name.
+    pub fn from_x360_name(name: &str) -> Option<&PartitionMapEntry> {
+        X360_PARTITION_LAYOUT
+            .iter()
+            .find(|&entry| entry.letter == name)
     }
 }

--- a/rust/fatx/src/variant.rs
+++ b/rust/fatx/src/variant.rs
@@ -1,0 +1,66 @@
+/// Which console's flavour of FATX a filesystem is.
+///
+/// The two are the same filesystem, but the Xbox 360 stores every multi-byte
+/// on-disk value big-endian, counts timestamps from 1980 rather than 2000, uses
+/// the standard FAT widths for the hour and minute fields, and stores the date
+/// before the time in each timestamp pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Variant {
+    /// Detect from the partition signature.
+    #[default]
+    Auto,
+    /// Original Xbox: little-endian on disk.
+    Xbox,
+    /// Xbox 360: big-endian on disk.
+    X360,
+}
+
+impl Variant {
+    /// Identify the variant from a raw, unswapped signature word.
+    ///
+    /// The signature is byte-identical in both flavours: the original Xbox
+    /// writes the bytes 'F','A','T','X' and reads them little-endian, the 360
+    /// writes 'X','T','A','F' and reads them big-endian, and both yield the
+    /// same value. So whichever way round the raw word matches identifies the
+    /// disk's byte order.
+    pub fn from_raw_signature(raw: u32, signature: u32) -> Option<Self> {
+        if raw == signature {
+            Some(Variant::Xbox)
+        } else if raw.swap_bytes() == signature {
+            Some(Variant::X360)
+        } else {
+            None
+        }
+    }
+
+    /// Whether values read off this disk need their bytes swapped.
+    ///
+    /// The on-disk structures are declared with little-endian field types, so
+    /// this is true exactly when the disk is big-endian.
+    pub fn needs_swap(&self) -> bool {
+        matches!(self, Variant::X360)
+    }
+
+    /// The year timestamps on this filesystem count from.
+    pub fn epoch(&self) -> u16 {
+        match self {
+            Variant::X360 => 1980,
+            _ => 2000,
+        }
+    }
+}
+
+impl std::str::FromStr for Variant {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(Variant::Auto),
+            "xbox" => Ok(Variant::Xbox),
+            "x360" => Ok(Variant::X360),
+            other => Err(format!(
+                "unknown variant '{other}' (expected auto, xbox or x360)"
+            )),
+        }
+    }
+}

--- a/tests/diag_stfs_names.sh
+++ b/tests/diag_stfs_names.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Diagnostic: for every STFS package whose display name failed to decode in
+# gate_real_drive.sh step 5, dump the header bytes around the display-name
+# field and the content-type/metadata-version fields, so we can tell whether
+# this is a misread FAT chain or just a header-layout variant the verifier
+# doesn't know about.
+#
+# Usage: sudo tests/diag_stfs_names.sh /dev/sdb data
+
+set -euo pipefail
+
+DEV="${1:-}"
+PART="${2:-data}"
+
+if [ -z "$DEV" ]; then
+    echo "usage: $0 <device> [partition]" >&2
+    exit 1
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FATXFS="${FATXFS:-$HERE/../install/bin/fatxfs}"
+OUT="$(pwd)/gate-results"
+MNT="$OUT/mnt"
+LISTING="$OUT/listing.txt"
+
+[ -x "$FATXFS" ] || { echo "fatxfs not found at $FATXFS" >&2; exit 1; }
+[ -f "$LISTING" ] || { echo "no listing.txt from a prior gate run at $LISTING" >&2; exit 1; }
+
+cleanup() {
+    mountpoint -q "$MNT" 2>/dev/null && fusermount -u "$MNT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$MNT"
+"$FATXFS" --variant=x360 --partition="$PART" --read-only \
+          --log="$OUT/diag_mount.log" --loglevel=2 "$DEV" "$MNT"
+
+python3 - "$MNT" "$LISTING" <<'PY'
+import os, sys
+
+mnt, listing = sys.argv[1], sys.argv[2]
+bad = []
+
+with open(listing) as f:
+    for line in f:
+        kind, size, rel = line.rstrip("\n").split(" ", 2)
+        if kind != "f" or int(size) < 0x1000:
+            continue
+        path = os.path.join(mnt, rel)
+        try:
+            with open(path, "rb") as fh:
+                head = fh.read(0x1000)
+        except OSError as e:
+            print(f"OPEN FAILED: {rel}: {e}")
+            continue
+        if head[:4] not in (b"CON ", b"LIVE", b"PIRS"):
+            continue
+        raw = head[0x411:0x411 + 0x80]
+        name = raw.decode("utf-16-be", "replace").split("\x00")[0].strip()
+        if not (name and all(ch.isprintable() for ch in name)):
+            bad.append((rel, size, head))
+
+print(f"{len(bad)} package(s) with unreadable display name at 0x411\n")
+
+for rel, size, head in bad:
+    print("=" * 70)
+    print(f"{rel}  (size={size})")
+    print(f"  magic:            {head[:4]!r}")
+    # candidate metadata fields per public STFS docs (offsets from file start)
+    print(f"  content type  @0x344: {head[0x344:0x348].hex()}")
+    print(f"  metadata ver  @0x348: {head[0x348:0x34c].hex()}")
+    print(f"  bytes 0x400-0x440 (display name region + neighbors):")
+    chunk = head[0x400:0x440]
+    hexline = " ".join(f"{b:02x}" for b in chunk)
+    print(f"    {hexline}")
+    # try a spread of plausible alternate offsets for the UTF-16BE name
+    for off in (0x411, 0x171, 0x1691, 0x3391, 0x395, 0x1191):
+        raw = head[off:off + 0x80]
+        name = raw.decode("utf-16-be", "replace").split("\x00")[0].strip()
+        printable = name and all(ch.isprintable() for ch in name)
+        flag = "OK" if printable else "--"
+        print(f"    [{flag}] @0x{off:04x}: {name!r}")
+    print()
+PY

--- a/tests/dump_x360_partition.sh
+++ b/tests/dump_x360_partition.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Dump a slice of an Xbox 360 hard drive partition for offline testing.
+#
+# This only ever reads from the device. It never writes to it.
+#
+# Usage: dump_x360_partition.sh <device> [partition] [size in MiB]
+#   e.g. dump_x360_partition.sh /dev/sdb data 256
+#
+# The 360 has no partition table: partitions live at fixed byte offsets, and
+# those offsets are not MiB-aligned, so the skip is done in bytes rather than
+# with a round block count.
+
+set -euo pipefail
+
+DEV="${1:-}"
+PART="${2:-data}"
+SIZE_MIB="${3:-256}"
+
+if [ -z "$DEV" ]; then
+    echo "usage: $0 <device> [sysext|sysext2|compat|data] [size in MiB]" >&2
+    exit 1
+fi
+
+case "$PART" in
+    sysext)  OFFSET=$((0x10C080000)) ;;
+    sysext2) OFFSET=$((0x118EB0000)) ;;
+    compat)  OFFSET=$((0x120EB0000)) ;;
+    data)    OFFSET=$((0x130EB0000)) ;;
+    *) echo "unknown partition '$PART' (expected sysext, sysext2, compat or data)" >&2; exit 1 ;;
+esac
+
+OUT="x360-${PART}.img"
+
+if [ ! -r "$DEV" ]; then
+    echo "cannot read $DEV -- run with sudo, or check the device path" >&2
+    exit 1
+fi
+
+echo "device    : $DEV"
+echo "partition : $PART"
+echo "offset    : $OFFSET bytes (0x$(printf '%X' $OFFSET))"
+echo "size      : ${SIZE_MIB} MiB"
+echo "output    : $OUT"
+echo
+
+# Check the signature before committing to a large read. The 360 writes the
+# bytes 'XTAF'; the original Xbox writes 'FATX'. Anything else means either the
+# wrong device or the wrong offset, and there is no point dumping it.
+SIG="$(dd if="$DEV" bs=1 skip="$OFFSET" count=4 status=none | tr -d '\0')"
+case "$SIG" in
+    XTAF)
+        echo "signature : XTAF -- Xbox 360 filesystem, as expected"
+        ;;
+    FATX)
+        echo "signature : FATX -- this is an ORIGINAL XBOX filesystem, not a 360 one." >&2
+        echo "            Wrong drive? Continuing anyway, but --variant=x360 will not apply." >&2
+        ;;
+    *)
+        echo "signature : '$SIG' -- not a FATX partition at this offset." >&2
+        echo "            Wrong device, or a drive whose layout differs from the standard map." >&2
+        echo "            Refusing to dump. Check the device with:" >&2
+        echo "              sudo dd if=$DEV bs=1 skip=$OFFSET count=64 | xxd | head" >&2
+        exit 1
+        ;;
+esac
+
+echo
+echo "dumping..."
+dd if="$DEV" of="$OUT" bs=1M count="$SIZE_MIB" \
+   skip="$OFFSET" iflag=skip_bytes status=progress
+
+echo
+echo "sha256: $(sha256sum "$OUT" | cut -d' ' -f1)"
+echo
+echo "Mount it read-only with:"
+echo "  mkdir -p /tmp/x360 && fatxfs --variant=x360 --offset=0 --size=$((SIZE_MIB * 1024 * 1024)) -o ro $OUT /tmp/x360"
+echo
+echo "Note: a partial dump truncates the partition, so any file whose data lives"
+echo "beyond ${SIZE_MIB} MiB will list correctly but fail to read in full."

--- a/tests/gate_real_drive.sh
+++ b/tests/gate_real_drive.sh
@@ -92,7 +92,7 @@ note "4. file contents must match their own format's magic"
 # These magic numbers are defined by Microsoft and by the image formats, not by
 # this project, so they are ground truth from outside the codebase. A FAT chain
 # that is followed incorrectly cannot land on the right magic by luck.
-python3 - "$MNT" "$OUT/listing.txt" <<'PY'
+if ! python3 - "$MNT" "$OUT/listing.txt" <<'PY'
 import os, struct, sys
 
 mnt, listing = sys.argv[1], sys.argv[2]
@@ -144,17 +144,23 @@ elif mismatched:
 else:
     print(f"   ok: {matched}/{checked} files match their format's magic")
 PY
-[ $? -eq 0 ] || fail=1
+then
+    fail=1
+fi
 
 note "5. STFS packages must be internally consistent"
-# An STFS header stores the display name as UTF-16BE at a fixed offset. Getting
-# readable text out of it means the cluster chain landed exactly right, not
-# merely on a plausible-looking first sector.
-python3 - "$MNT" "$OUT/listing.txt" <<'PY'
-import os, sys
+# An STFS header stores the display name as UTF-16BE at 0x411 -- but only for
+# content types that actually carry one. Saved Game (0x1), Profile (0x10000)
+# and Cache File (0x40000) packages leave that field blank or reuse it for
+# something else, confirmed on real drive data: unrelated saves across
+# different games decode to byte-identical bytes at 0x411, which a misread
+# FAT chain could not produce. So those types are skipped, not required.
+if ! python3 - "$MNT" "$OUT/listing.txt" <<'PY'
+import os, struct, sys
 
 mnt, listing = sys.argv[1], sys.argv[2]
-ok = bad = 0
+NO_DISPLAY_NAME = {0x00000001, 0x00010000, 0x00040000}
+ok = bad = skipped = 0
 samples = []
 
 with open(listing) as f:
@@ -169,6 +175,10 @@ with open(listing) as f:
             continue
         if not head[:4] in (b"CON ", b"LIVE", b"PIRS"):
             continue
+        content_type = struct.unpack(">I", head[0x344:0x348])[0]
+        if content_type in NO_DISPLAY_NAME:
+            skipped += 1
+            continue
         # Display name: UTF-16BE at 0x411 in the STFS metadata.
         raw = head[0x411:0x411 + 0x80]
         name = raw.decode("utf-16-be", "replace").split("\x00")[0].strip()
@@ -178,18 +188,23 @@ with open(listing) as f:
                 samples.append((name, rel))
         else:
             bad += 1
+            print(f"   UNREADABLE: {rel} (content type 0x{content_type:08x})")
 
 for name, rel in samples:
     print(f'   "{name}"')
+if skipped:
+    print(f"   ({skipped} save/profile/cache package(s) skipped -- no display name field)")
 if ok == 0 and bad == 0:
-    print("   (no STFS packages on this partition)")
+    print("   (no title-carrying STFS packages on this partition)")
 elif bad:
     print(f"   FAILED: {bad} package(s) had unreadable display names ({ok} ok)")
     sys.exit(1)
 else:
     print(f"   ok: {ok} STFS package(s) with readable display names")
 PY
-[ $? -eq 0 ] || fail=1
+then
+    fail=1
+fi
 
 note "6. cross-check against the independent Rust implementation"
 if [ -x "$FATXFUSE" ]; then

--- a/tests/gate_real_drive.sh
+++ b/tests/gate_real_drive.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# Verification gate: read a real Xbox 360 drive and check the result is sane.
+#
+# This only ever reads. It mounts with --read-only, which opens the device
+# without write access at all rather than relying on FUSE's -o ro.
+#
+# Usage: sudo tests/gate_real_drive.sh /dev/sdX [partition]
+#
+# What it establishes, and what it does not:
+#
+#   The synthetic tests prove the driver is self-consistent. They cannot prove
+#   it reads a real disk correctly, because they only ever read images built to
+#   the same understanding of the format. This walks an actual console's
+#   filesystem end to end and checks the contents against facts that come from
+#   outside this project: file formats with their own magic numbers and
+#   internal length fields, which cannot survive a misread FAT chain.
+#
+#   It still is not a listing captured from the console itself. If you can pull
+#   one over FTP, diff it against listing.txt below -- that is the last check
+#   this cannot do for itself.
+
+set -euo pipefail
+
+DEV="${1:-}"
+PART="${2:-data}"
+
+if [ -z "$DEV" ]; then
+    echo "usage: $0 <device> [sysext|sysext2|compat|data]" >&2
+    exit 1
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FATXFS="${FATXFS:-$HERE/../install/bin/fatxfs}"
+FATXFUSE="${FATXFUSE:-$HERE/../rust/target/release/fatx-fuse}"
+OUT="$(pwd)/gate-results"
+MNT="$OUT/mnt"
+RUSTMNT="$OUT/rustmnt"
+
+[ -x "$FATXFS" ] || { echo "fatxfs not found at $FATXFS" >&2; exit 1; }
+
+cleanup() {
+    mountpoint -q "$MNT" 2>/dev/null && fusermount -u "$MNT" 2>/dev/null || true
+    mountpoint -q "$RUSTMNT" 2>/dev/null && fusermount -u "$RUSTMNT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$MNT" "$RUSTMNT"
+fail=0
+note() { echo; echo "== $* =="; }
+
+note "1. mounting $DEV partition '$PART' read-only"
+"$FATXFS" --variant=x360 --partition="$PART" --read-only \
+          --log="$OUT/mount.log" --loglevel=4 "$DEV" "$MNT"
+grep -E 'Variant|Sectors per Cluster|FAT Type|# of Clusters' "$OUT/mount.log" | sed 's/^/   /'
+
+note "2. full recursive listing"
+# find's own errors matter: on a whole drive every directory must be
+# enumerable, and anything that is not is a real failure rather than noise.
+( cd "$MNT" && find . -mindepth 1 -printf '%y %s %P\n' 2> "$OUT/find-errors.txt" | sort ) \
+    > "$OUT/listing.txt" || true
+printf '   %s entries (%s files, %s dirs)\n' \
+    "$(wc -l < "$OUT/listing.txt")" \
+    "$(grep -c '^f' "$OUT/listing.txt" || true)" \
+    "$(grep -c '^d' "$OUT/listing.txt" || true)"
+if [ -s "$OUT/find-errors.txt" ]; then
+    echo "   $(wc -l < "$OUT/find-errors.txt") directory error(s):"
+    head -5 "$OUT/find-errors.txt" | sed 's/^/     /'
+    echo "     (on a whole drive this should be empty; on a truncated dump it"
+    echo "      just means those clusters were past the end of the file)"
+    fail=1
+fi
+
+note "3. every file must be readable in full"
+# A misread FAT chain typically shows up as a short read or an I/O error long
+# before it shows up as wrong content.
+unreadable=0
+while IFS= read -r rel; do
+    if ! dd if="$MNT/$rel" of=/dev/null bs=1M status=none 2>/dev/null; then
+        echo "   UNREADABLE: $rel"
+        unreadable=$((unreadable + 1))
+    fi
+done < <(grep '^f ' "$OUT/listing.txt" | cut -d' ' -f3-)
+if [ "$unreadable" -gt 0 ]; then
+    echo "   $unreadable file(s) failed to read"
+    fail=1
+else
+    echo "   ok: all files read to completion"
+fi
+
+note "4. file contents must match their own format's magic"
+# These magic numbers are defined by Microsoft and by the image formats, not by
+# this project, so they are ground truth from outside the codebase. A FAT chain
+# that is followed incorrectly cannot land on the right magic by luck.
+python3 - "$MNT" "$OUT/listing.txt" <<'PY'
+import os, struct, sys
+
+mnt, listing = sys.argv[1], sys.argv[2]
+
+# (description, extensions, expected leading bytes)
+MAGIC = [
+    ("STFS package", (),            (b"CON ", b"LIVE", b"PIRS")),
+    ("XEX executable", (".xex",),   (b"XEX2", b"XEX1")),
+    ("JPEG",         (".jpg", ".jpeg"), (b"\xff\xd8\xff",)),
+    ("PNG",          (".png",),     (b"\x89PNG\r\n\x1a\n",)),
+]
+
+checked = matched = mismatched = 0
+by_kind = {}
+
+with open(listing) as f:
+    for line in f:
+        kind, size, rel = line.rstrip("\n").split(" ", 2)
+        if kind != "f" or int(size) < 4:
+            continue
+        path = os.path.join(mnt, rel)
+        try:
+            with open(path, "rb") as fh:
+                head = fh.read(8)
+        except OSError:
+            continue
+
+        ext = os.path.splitext(rel)[1].lower()
+        for desc, exts, magics in MAGIC:
+            applies = (ext in exts) if exts else any(head.startswith(m) for m in magics)
+            if not applies:
+                continue
+            checked += 1
+            if any(head.startswith(m) for m in magics):
+                matched += 1
+                by_kind[desc] = by_kind.get(desc, 0) + 1
+            else:
+                mismatched += 1
+                print(f"   MISMATCH: {rel} claims {desc} but starts {head[:4]!r}")
+            break
+
+for desc, n in sorted(by_kind.items()):
+    print(f"   {n:5d}  {desc}")
+if checked == 0:
+    print("   (no files with recognisable magic found)")
+elif mismatched:
+    print(f"   FAILED: {mismatched} of {checked} did not match")
+    sys.exit(1)
+else:
+    print(f"   ok: {matched}/{checked} files match their format's magic")
+PY
+[ $? -eq 0 ] || fail=1
+
+note "5. STFS packages must be internally consistent"
+# An STFS header stores the display name as UTF-16BE at a fixed offset. Getting
+# readable text out of it means the cluster chain landed exactly right, not
+# merely on a plausible-looking first sector.
+python3 - "$MNT" "$OUT/listing.txt" <<'PY'
+import os, sys
+
+mnt, listing = sys.argv[1], sys.argv[2]
+ok = bad = 0
+samples = []
+
+with open(listing) as f:
+    for line in f:
+        kind, size, rel = line.rstrip("\n").split(" ", 2)
+        if kind != "f" or int(size) < 0x1000:
+            continue
+        try:
+            with open(os.path.join(mnt, rel), "rb") as fh:
+                head = fh.read(0x500)
+        except OSError:
+            continue
+        if not head[:4] in (b"CON ", b"LIVE", b"PIRS"):
+            continue
+        # Display name: UTF-16BE at 0x411 in the STFS metadata.
+        raw = head[0x411:0x411 + 0x80]
+        name = raw.decode("utf-16-be", "replace").split("\x00")[0].strip()
+        if name and all(ch.isprintable() for ch in name):
+            ok += 1
+            if len(samples) < 6:
+                samples.append((name, rel))
+        else:
+            bad += 1
+
+for name, rel in samples:
+    print(f'   "{name}"')
+if ok == 0 and bad == 0:
+    print("   (no STFS packages on this partition)")
+elif bad:
+    print(f"   FAILED: {bad} package(s) had unreadable display names ({ok} ok)")
+    sys.exit(1)
+else:
+    print(f"   ok: {ok} STFS package(s) with readable display names")
+PY
+[ $? -eq 0 ] || fail=1
+
+note "6. cross-check against the independent Rust implementation"
+if [ -x "$FATXFUSE" ]; then
+    "$FATXFUSE" --variant=x360 --partition="$PART" "$DEV" "$RUSTMNT" 2>/dev/null &
+    for _ in $(seq 1 50); do mountpoint -q "$RUSTMNT" && break; sleep 0.2; done
+    ( cd "$RUSTMNT" && find . -mindepth 1 -printf '%y %s %P\n' | sort ) > "$OUT/listing-rust.txt"
+    if diff -q "$OUT/listing.txt" "$OUT/listing-rust.txt" > /dev/null; then
+        echo "   ok: C and Rust drivers produce identical listings"
+    else
+        echo "   MISMATCH between the two implementations:"
+        diff "$OUT/listing.txt" "$OUT/listing-rust.txt" | head -20
+        fail=1
+    fi
+    fusermount -u "$RUSTMNT" 2>/dev/null || true
+else
+    echo "   skipped: fatx-fuse not built at $FATXFUSE"
+fi
+
+note "RESULT"
+if [ "$fail" -eq 0 ]; then
+    echo "   GATE PASSED"
+else
+    echo "   GATE FAILED -- do not write to a real drive"
+fi
+echo
+echo "   Listing written to $OUT/listing.txt"
+echo "   Remaining check this cannot do for itself: pull a listing from the"
+echo "   console over FTP and diff it against that file."
+exit "$fail"

--- a/tests/gate_recheck.sh
+++ b/tests/gate_recheck.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Fast re-check: reuses the listing.txt from a prior full gate_real_drive.sh
+# run and only re-runs step 5 (STFS display names, now content-type aware)
+# and step 6 (Rust cross-check). Skips the full byte-for-byte file read.
+#
+# Usage: sudo tests/gate_recheck.sh /dev/sdb data
+
+set -euo pipefail
+
+DEV="${1:-}"
+PART="${2:-data}"
+
+if [ -z "$DEV" ]; then
+    echo "usage: $0 <device> [partition]" >&2
+    exit 1
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FATXFS="${FATXFS:-$HERE/../install/bin/fatxfs}"
+FATXFUSE="${FATXFUSE:-$HERE/../rust/target/release/fatx-fuse}"
+OUT="$(pwd)/gate-results"
+MNT="$OUT/mnt"
+RUSTMNT="$OUT/rustmnt"
+LISTING="$OUT/listing.txt"
+
+[ -x "$FATXFS" ] || { echo "fatxfs not found at $FATXFS" >&2; exit 1; }
+[ -f "$LISTING" ] || { echo "no listing.txt from a prior gate run at $LISTING" >&2; exit 1; }
+
+cleanup() {
+    mountpoint -q "$MNT" 2>/dev/null && fusermount -u "$MNT" 2>/dev/null || true
+    mountpoint -q "$RUSTMNT" 2>/dev/null && fusermount -u "$RUSTMNT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$MNT" "$RUSTMNT"
+fail=0
+note() { echo; echo "== $* =="; }
+
+note "mounting $DEV partition '$PART' read-only"
+"$FATXFS" --variant=x360 --partition="$PART" --read-only \
+          --log="$OUT/recheck_mount.log" --loglevel=2 "$DEV" "$MNT"
+
+note "5. STFS packages must be internally consistent (reusing $LISTING)"
+if ! python3 - "$MNT" "$LISTING" <<'PY'
+import os, struct, sys
+
+mnt, listing = sys.argv[1], sys.argv[2]
+NO_DISPLAY_NAME = {0x00000001, 0x00010000, 0x00040000}
+ok = bad = skipped = 0
+samples = []
+
+with open(listing) as f:
+    for line in f:
+        kind, size, rel = line.rstrip("\n").split(" ", 2)
+        if kind != "f" or int(size) < 0x1000:
+            continue
+        try:
+            with open(os.path.join(mnt, rel), "rb") as fh:
+                head = fh.read(0x500)
+        except OSError:
+            continue
+        if not head[:4] in (b"CON ", b"LIVE", b"PIRS"):
+            continue
+        content_type = struct.unpack(">I", head[0x344:0x348])[0]
+        if content_type in NO_DISPLAY_NAME:
+            skipped += 1
+            continue
+        raw = head[0x411:0x411 + 0x80]
+        name = raw.decode("utf-16-be", "replace").split("\x00")[0].strip()
+        if name and all(ch.isprintable() for ch in name):
+            ok += 1
+            if len(samples) < 6:
+                samples.append((name, rel))
+        else:
+            bad += 1
+            print(f"   UNREADABLE: {rel} (content type 0x{content_type:08x})")
+
+for name, rel in samples:
+    print(f'   "{name}"')
+if skipped:
+    print(f"   ({skipped} save/profile/cache package(s) skipped -- no display name field)")
+if ok == 0 and bad == 0:
+    print("   (no title-carrying STFS packages on this partition)")
+elif bad:
+    print(f"   FAILED: {bad} package(s) had unreadable display names ({ok} ok)")
+    sys.exit(1)
+else:
+    print(f"   ok: {ok} STFS package(s) with readable display names")
+PY
+then
+    fail=1
+fi
+
+note "6. cross-check against the independent Rust implementation"
+if [ -x "$FATXFUSE" ]; then
+    "$FATXFUSE" --variant=x360 --partition="$PART" "$DEV" "$RUSTMNT" 2>/dev/null &
+    for _ in $(seq 1 50); do mountpoint -q "$RUSTMNT" && break; sleep 0.2; done
+    ( cd "$RUSTMNT" && find . -mindepth 1 -printf '%y %s %P\n' | sort ) > "$OUT/listing-rust.txt"
+    if diff -q "$LISTING" "$OUT/listing-rust.txt" > /dev/null; then
+        echo "   ok: C and Rust drivers produce identical listings"
+    else
+        echo "   MISMATCH between the two implementations:"
+        diff "$LISTING" "$OUT/listing-rust.txt" | head -20
+        fail=1
+    fi
+    fusermount -u "$RUSTMNT" 2>/dev/null || true
+else
+    echo "   skipped: fatx-fuse not built at $FATXFUSE"
+fi
+
+note "RESULT"
+if [ "$fail" -eq 0 ]; then
+    echo "   GATE PASSED"
+else
+    echo "   GATE FAILED -- do not write to a real drive"
+fi
+exit "$fail"

--- a/tests/hw_write_test.sh
+++ b/tests/hw_write_test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# First real-hardware write test against the 360 HDD's `data` partition.
+#
+# Scope, deliberately narrow: creates exactly one new top-level folder
+# (_fatx360_write_test/) and touches nothing that already exists. Backs up
+# the boot sector + FAT before writing anything. Verifies the result three
+# ways: read-back through the driver, independent raw decode of the on-disk
+# bytes (shares no code with libfatx), and a structural re-listing diffed
+# against the last full gate run to prove nothing pre-existing moved.
+#
+# This does NOT delete the test folder -- leave it in place so the console
+# can be booted against it and checked over FTP/XeXMenu. Run
+# hw_write_test_cleanup.sh afterward once that's confirmed.
+#
+# Usage: sudo tests/hw_write_test.sh /dev/sdb
+
+set -euo pipefail
+
+DEV="${1:-}"
+[ -z "$DEV" ] && { echo "usage: $0 <device>" >&2; exit 1; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FATXFS="${FATXFS:-$HERE/../install/bin/fatxfs}"
+OUT="$(pwd)/gate-results"
+MNT="$OUT/mnt"
+BACKUP="$OUT/data_partition_boot_and_fat.img"
+LISTING="$OUT/listing.txt"
+
+DATA_OFFSET=$((0x130EB0000))
+BACKUP_SIZE=242946048        # 4096-byte superblock + FAT, computed from fatx.c's own layout math
+CLUSTER_OFFSET=5358620672    # fs->cluster_offset for this drive's data partition (root dir cluster 1)
+BYTES_PER_CLUSTER=16384
+
+[ -x "$FATXFS" ] || { echo "fatxfs not found at $FATXFS" >&2; exit 1; }
+[ -f "$LISTING" ] || { echo "no prior listing.txt at $LISTING -- run gate_real_drive.sh first" >&2; exit 1; }
+
+cleanup_mount() {
+    mountpoint -q "$MNT" 2>/dev/null && fusermount -u "$MNT" 2>/dev/null || true
+}
+trap cleanup_mount EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "$MNT"
+
+echo "== 0. backing up boot sector + FAT ($BACKUP_SIZE bytes) =="
+if [ -f "$BACKUP" ] && [ "$(stat -c %s "$BACKUP")" -eq "$BACKUP_SIZE" ]; then
+    echo "   ok: pre-write backup already exists at $BACKUP, not overwriting it"
+else
+    dd if="$DEV" of="$BACKUP" bs=512 skip=$((DATA_OFFSET / 512)) count=$((BACKUP_SIZE / 512)) status=none
+    [ "$(stat -c %s "$BACKUP")" -eq "$BACKUP_SIZE" ] || fail "backup came back the wrong size"
+    echo "   ok: saved to $BACKUP"
+fi
+
+mount_rw() {
+    "$FATXFS" --variant=x360 --partition=data --log="$OUT/hw_write.log" --loglevel=3 "$DEV" "$MNT"
+    for _ in $(seq 1 50); do mountpoint -q "$MNT" && return 0; sleep 0.2; done
+    fail "read-write mount did not come up"
+}
+mount_ro() {
+    "$FATXFS" --variant=x360 --partition=data --read-only --log="$OUT/hw_write_ro.log" --loglevel=3 "$DEV" "$MNT"
+    for _ in $(seq 1 50); do mountpoint -q "$MNT" && return 0; sleep 0.2; done
+    fail "read-only mount did not come up"
+}
+unmount() {
+    fusermount -u "$MNT"
+    for _ in $(seq 1 50); do mountpoint -q "$MNT" || return 0; sleep 0.2; done
+    fail "unmount did not complete"
+}
+
+TESTDIR="_fatx360_write_test"
+
+echo
+echo "== 1. mounting read-write, creating $TESTDIR/ =="
+mount_rw
+if [ -d "$MNT/$TESTDIR" ]; then
+    echo "   ok: $TESTDIR already exists on the drive from a prior run, not re-writing it"
+else
+    mkdir "$MNT/$TESTDIR"
+    echo "fatx360 hardware write test $(date -Iseconds)" > "$MNT/$TESTDIR/HELLO.TXT"
+    [ -f "$OUT/big_local.bin" ] || head -c 102400 /dev/urandom > "$OUT/big_local.bin"
+    cp "$OUT/big_local.bin" "$MNT/$TESTDIR/BIG.BIN"
+    mkdir "$MNT/$TESTDIR/NESTED"
+    echo "nested file" > "$MNT/$TESTDIR/NESTED/INNER.TXT"
+fi
+unmount
+echo "   ok: written and unmounted cleanly"
+
+echo
+echo "== 2. independent raw decode of the root directory =="
+# The decoder scans the WHOLE root directory, not just what we wrote -- other
+# pre-existing entries (e.g. from unrelated console-side tools) may already
+# carry issues that have nothing to do with this test. Only what we ourselves
+# wrote is grounds to fail here.
+python3 "$HERE/verify_x360_dirents.py" "$DEV" "$CLUSTER_OFFSET" "$BYTES_PER_CLUSTER" \
+    > "$OUT/hw_write_raw_decode.txt" || true
+cat "$OUT/hw_write_raw_decode.txt"
+OUR_LINE="$(grep "^${TESTDIR}[[:space:]]" "$OUT/hw_write_raw_decode.txt" || true)"
+[ -n "$OUR_LINE" ] || fail "$TESTDIR does not appear in the independently-decoded root directory"
+case "$OUR_LINE" in
+    *IMPLAUSIBLE*) fail "$TESTDIR has an implausible timestamp in the raw decode: $OUR_LINE" ;;
+esac
+PADDING_LINE="$(grep '^FAIL: filename padding carries junk in:' "$OUT/hw_write_raw_decode.txt" || true)"
+if [ -n "$PADDING_LINE" ]; then
+    case "$PADDING_LINE" in
+        *"$TESTDIR"*) fail "our own write left garbage in filename padding: $PADDING_LINE" ;;
+        *) echo "   note: pre-existing unrelated entries flagged for padding junk (not from this test): $PADDING_LINE" ;;
+    esac
+fi
+echo "   ok: $TESTDIR present and well-formed in the raw on-disk root directory"
+
+echo
+echo "== 3. remounting read-only, verifying new files byte-exact =="
+mount_ro
+cmp "$MNT/$TESTDIR/BIG.BIN" "$OUT/big_local.bin" || fail "multi-cluster file did not survive"
+[ "$(cat "$MNT/$TESTDIR/NESTED/INNER.TXT")" = "nested file" ] || fail "nested file lost"
+[ -f "$MNT/$TESTDIR/HELLO.TXT" ] || fail "top-level file lost"
+echo "   ok: all new files read back byte-exact"
+
+echo
+echo "== 4. confirming nothing pre-existing moved =="
+( cd "$MNT" && find . -mindepth 1 -not -path "./$TESTDIR*" -printf '%y %s %P\n' | sort ) \
+    > "$OUT/listing_after_write.txt"
+if diff -q "$LISTING" "$OUT/listing_after_write.txt" > /dev/null; then
+    echo "   ok: every pre-existing entry (path, size, kind) is unchanged"
+else
+    echo "   MISMATCH -- something pre-existing changed:"
+    diff "$LISTING" "$OUT/listing_after_write.txt" | head -20
+    unmount
+    fail "pre-existing data was disturbed"
+fi
+unmount
+
+echo
+echo "== RESULT: HARDWARE WRITE TEST PASSED =="
+echo "   $TESTDIR/ is on the drive now. Move it to the console, boot, and check"
+echo "   over FTP/XeXMenu that the dash reads it fine and the folder is there."
+echo "   Once confirmed, run: sudo tests/hw_write_test_cleanup.sh $DEV"

--- a/tests/hw_write_test_cleanup.sh
+++ b/tests/hw_write_test_cleanup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Removes the _fatx360_write_test/ folder created by hw_write_test.sh.
+# Run this only after the console has confirmed it reads the drive fine.
+#
+# Usage: sudo tests/hw_write_test_cleanup.sh /dev/sdb
+
+set -euo pipefail
+
+DEV="${1:-}"
+[ -z "$DEV" ] && { echo "usage: $0 <device>" >&2; exit 1; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FATXFS="${FATXFS:-$HERE/../install/bin/fatxfs}"
+OUT="$(pwd)/gate-results"
+MNT="$OUT/mnt"
+LISTING="$OUT/listing.txt"
+TESTDIR="_fatx360_write_test"
+
+cleanup_mount() {
+    mountpoint -q "$MNT" 2>/dev/null && fusermount -u "$MNT" 2>/dev/null || true
+}
+trap cleanup_mount EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "$MNT"
+"$FATXFS" --variant=x360 --partition=data --log="$OUT/hw_cleanup.log" --loglevel=3 "$DEV" "$MNT"
+for _ in $(seq 1 50); do mountpoint -q "$MNT" && break; sleep 0.2; done
+
+[ -d "$MNT/$TESTDIR" ] || fail "$TESTDIR not found on the drive"
+rm -rf "$MNT/$TESTDIR"
+
+fusermount -u "$MNT"
+for _ in $(seq 1 50); do mountpoint -q "$MNT" || break; sleep 0.2; done
+
+echo "== remounting read-only to confirm the drive is back to its original state =="
+"$FATXFS" --variant=x360 --partition=data --read-only --log="$OUT/hw_cleanup_ro.log" --loglevel=3 "$DEV" "$MNT"
+for _ in $(seq 1 50); do mountpoint -q "$MNT" && break; sleep 0.2; done
+
+( cd "$MNT" && find . -mindepth 1 -printf '%y %s %P\n' | sort ) > "$OUT/listing_after_cleanup.txt"
+fusermount -u "$MNT"
+
+if diff -q "$LISTING" "$OUT/listing_after_cleanup.txt" > /dev/null; then
+    echo "ok: drive listing matches the original gate run exactly -- clean"
+else
+    echo "MISMATCH after cleanup:"
+    diff "$LISTING" "$OUT/listing_after_cleanup.txt" | head -20
+    exit 1
+fi

--- a/tests/make_x360_image.py
+++ b/tests/make_x360_image.py
@@ -51,11 +51,16 @@ END_OF_DIR_MARKER = 0xFF
 FAT16_END_OF_CHAIN = 0xFFFF
 FAT16_MEDIA = 0xFFF8
 
-# Timestamp fields are packed with the original Xbox epoch (2000). Whether the
-# 360 uses 1980 instead is an open question that only a real disk can settle, so
-# the accompanying test asserts on names, sizes and contents and treats
-# timestamps as informational.
-EPOCH = 2000
+# Timestamps. All three of these differ from the original Xbox, and all three
+# were established from a retail 360 disk:
+#   - the epoch is 1980, not 2000 (factory files are stamped 2005-11-22, the
+#     console's launch date, which only decodes correctly from a 1980 base);
+#   - the time field uses the standard FAT widths of 5 bits for the hour and 6
+#     for the minute, not the original Xbox's 4 and 5 (a real disk carries
+#     hours of 21 and 23 and minutes of 50 and 59);
+#   - the date is stored BEFORE the time in each pair, the opposite of the
+#     original Xbox.
+EPOCH = 1980
 
 
 def pack_date(year, month, day):
@@ -63,11 +68,14 @@ def pack_date(year, month, day):
 
 
 def pack_time(hour, minute, second):
-    return (((hour & 0xF) << 11) | ((minute & 0x1F) << 5) | ((second // 2) & 0x1F))
+    return (((hour & 0x1F) << 11) | ((minute & 0x3F) << 5) | ((second // 2) & 0x1F))
 
 
-DATE = pack_date(2026, 8, 11)
-TIME = pack_time(14, 30, 0)
+# Deliberately uses an hour and a minute that do not fit the original Xbox's
+# narrower fields, so a regression to those widths cannot pass unnoticed.
+STAMP = (2026, 8, 11, 23, 50, 30)
+DATE = pack_date(*STAMP[:3])
+TIME = pack_time(*STAMP[3:])
 
 
 def superblock():
@@ -94,9 +102,9 @@ def dirent(name, attributes, first_cluster, file_size):
         ">IIHHHHHH",
         first_cluster,
         file_size,
-        TIME, DATE,   # modified
-        TIME, DATE,   # created
-        TIME, DATE,   # accessed
+        DATE, TIME,   # modified -- date first, unlike the original Xbox
+        DATE, TIME,   # created
+        DATE, TIME,   # accessed
     )
     assert len(entry) == DIRENT_SIZE, len(entry)
     return entry

--- a/tests/make_x360_image.py
+++ b/tests/make_x360_image.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+#
+# FATX Filesystem Library
+#
+# Copyright (C) 2026  Mijael Viricochea
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Build a minimal Xbox 360 (big-endian) FATX partition image.
+
+This assembles the on-disk structures byte by byte from the format spec, rather
+than by running libfatx's own writer. That is the whole point: an image produced
+by the library's writer would round-trip through the library's reader even if a
+field were left unswapped, because the same mistake would cancel out. An image
+built independently here does not, so mounting it exercises whether every
+multi-byte field is actually being byte-swapped.
+
+Everything multi-byte is emitted big-endian ('>' struct prefix).
+"""
+
+import struct
+import sys
+
+SECTOR_SIZE = 512
+SECTORS_PER_CLUSTER = 32
+BYTES_PER_CLUSTER = SECTOR_SIZE * SECTORS_PER_CLUSTER  # 16 KiB
+PARTITION_SIZE = 16 * 1024 * 1024                      # 16 MiB
+SUPERBLOCK_SIZE = 4096
+FAT_OFFSET = 4096
+VOLUME_ID = 0xCAFEBABE
+ROOT_CLUSTER = 1
+
+DIRENT_SIZE = 64
+MAX_FILENAME_LEN = 42
+
+ATTR_DIRECTORY = 1 << 4
+END_OF_DIR_MARKER = 0xFF
+
+FAT16_END_OF_CHAIN = 0xFFFF
+FAT16_MEDIA = 0xFFF8
+
+# Timestamp fields are packed with the original Xbox epoch (2000). Whether the
+# 360 uses 1980 instead is an open question that only a real disk can settle, so
+# the accompanying test asserts on names, sizes and contents and treats
+# timestamps as informational.
+EPOCH = 2000
+
+
+def pack_date(year, month, day):
+    return ((day & 0x1F) | ((month & 0xF) << 5) | (((year - EPOCH) & 0x7F) << 9))
+
+
+def pack_time(hour, minute, second):
+    return (((hour & 0xF) << 11) | ((minute & 0x1F) << 5) | ((second // 2) & 0x1F))
+
+
+DATE = pack_date(2026, 8, 11)
+TIME = pack_time(14, 30, 0)
+
+
+def superblock():
+    """4096 bytes. Signature is 'XTAF' -- the bytes that read big-endian give
+    the same 0x58544146 that 'FATX' gives when read little-endian."""
+    sb = struct.pack(
+        ">IIIIH",
+        0x58544146,           # signature
+        VOLUME_ID,            # volume_id
+        SECTORS_PER_CLUSTER,  # sectors_per_cluster
+        ROOT_CLUSTER,         # root_cluster
+        0,                    # unknown1
+    )
+    assert sb[:4] == b"XTAF", "signature bytes should spell XTAF on disk"
+    return sb + b"\xFF" * (SUPERBLOCK_SIZE - len(sb))
+
+
+def dirent(name, attributes, first_cluster, file_size):
+    name = name.encode("ascii")
+    assert len(name) < MAX_FILENAME_LEN
+    entry = struct.pack(">BB", len(name), attributes)
+    entry += name + b"\xFF" * (MAX_FILENAME_LEN - len(name))
+    entry += struct.pack(
+        ">IIHHHHHH",
+        first_cluster,
+        file_size,
+        TIME, DATE,   # modified
+        TIME, DATE,   # created
+        TIME, DATE,   # accessed
+    )
+    assert len(entry) == DIRENT_SIZE, len(entry)
+    return entry
+
+
+def build():
+    # Geometry, mirroring what fatx_open_device derives.
+    fat_entries = PARTITION_SIZE // BYTES_PER_CLUSTER + 1
+    assert fat_entries < 0xFFF0, "expected a FAT16 filesystem for this test"
+    fat_size = fat_entries * 2
+    if fat_size % 4096:
+        fat_size += 4096 - fat_size % 4096
+    cluster_offset = FAT_OFFSET + fat_size
+
+    image = bytearray(b"\x00" * PARTITION_SIZE)
+
+    # Superblock.
+    image[0:SUPERBLOCK_SIZE] = superblock()
+
+    # Contents. Cluster 1 is the root directory.
+    hello = b"Hello from a big-endian Xbox 360 filesystem.\n"
+    cover = bytes(range(256)) * 8  # 2048 bytes of non-trivial, checkable data
+
+    files = {
+        2: hello,   # /HELLO.TXT
+        4: cover,   # /GAMES/COVER.JPG
+    }
+
+    # FAT16. Entry 0 is the media descriptor; every file and directory here is a
+    # single cluster, so each of their entries is an end-of-chain marker.
+    fat = bytearray(fat_size)
+    struct.pack_into(">H", fat, 0, FAT16_MEDIA)
+    for cluster in (1, 2, 3, 4):
+        struct.pack_into(">H", fat, cluster * 2, FAT16_END_OF_CHAIN)
+    image[FAT_OFFSET:FAT_OFFSET + fat_size] = fat
+
+    def cluster_at(n):
+        return cluster_offset + (n - 1) * BYTES_PER_CLUSTER
+
+    # Root directory (cluster 1).
+    root = dirent("HELLO.TXT", 0, 2, len(hello))
+    root += dirent("GAMES", ATTR_DIRECTORY, 3, 0)
+    root += bytes([END_OF_DIR_MARKER])
+    image[cluster_at(1):cluster_at(1) + len(root)] = root
+
+    # /GAMES directory (cluster 3).
+    games = dirent("COVER.JPG", 0, 4, len(cover))
+    games += bytes([END_OF_DIR_MARKER])
+    image[cluster_at(3):cluster_at(3) + len(games)] = games
+
+    # File data.
+    for cluster, data in files.items():
+        image[cluster_at(cluster):cluster_at(cluster) + len(data)] = data
+
+    return bytes(image), {"/HELLO.TXT": hello, "/GAMES/COVER.JPG": cover}
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <output image>", file=sys.stderr)
+        return 1
+
+    image, contents = build()
+    with open(sys.argv[1], "wb") as f:
+        f.write(image)
+
+    # Emit the expected listing for the test script to diff against.
+    for path, data in sorted(contents.items()):
+        print(f"{path} {len(data)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_x360_read.sh
+++ b/tests/test_x360_read.sh
@@ -70,6 +70,17 @@ if actual != expected:
 EOF
 echo "ok: both files read back byte-exact"
 
+echo
+echo "== 3b. timestamps should decode with the 360's own rules =="
+# 2026-08-11 23:50:30. The hour and minute are chosen so that the original
+# Xbox's narrower fields would mangle them into 07:18 rather than 23:50.
+STAMP="$(date -d @"$(stat -c %Y "$MNT/HELLO.TXT")" '+%Y-%m-%d %H:%M:%S')"
+[ "$STAMP" = "2026-08-11 23:50:30" ] \
+    || fail "timestamp is $STAMP, expected 2026-08-11 23:50:30
+(2046-* means the epoch reverted to 2000; *07:18* means the time field
+reverted to the original Xbox's 4-bit hour and 5-bit minute)"
+echo "ok: $STAMP"
+
 fusermount -u "$MNT"
 
 echo

--- a/tests/test_x360_read.sh
+++ b/tests/test_x360_read.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Mount a synthetic big-endian (Xbox 360) FATX image and verify its contents.
+#
+# The image is assembled independently of libfatx by make_x360_image.py, so a
+# multi-byte field that is never byte-swapped shows up here as a wrong name,
+# size, or content -- which an image written by libfatx's own writer would hide.
+#
+# Requires fatxfs on PATH.
+
+set -eu
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+MNT="$WORK/mnt"
+IMG="$WORK/x360.img"
+
+cleanup() {
+    if mountpoint -q "$MNT" 2>/dev/null; then
+        fusermount -u "$MNT" || true
+    fi
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+mkdir -p "$MNT"
+
+echo "== building synthetic big-endian image =="
+python3 "$HERE/make_x360_image.py" "$IMG" > "$WORK/expected.txt"
+cat "$WORK/expected.txt"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo
+echo "== 1. auto-detection should identify it as x360 =="
+fatxfs --offset=0 --size=$((16 * 1024 * 1024)) \
+       --log="$WORK/mount.log" --loglevel=4 "$IMG" "$MNT"
+grep -q "detected x360 filesystem" "$WORK/mount.log" \
+    || fail "auto-detection did not report an x360 filesystem:
+$(cat "$WORK/mount.log")"
+echo "ok: $(grep -h 'detected' "$WORK/mount.log")"
+
+echo
+echo "== 2. directory tree should match =="
+ACTUAL="$(cd "$MNT" && find . -type f -printf '/%P %s\n' | sort)"
+EXPECTED="$(sort "$WORK/expected.txt")"
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    fail "listing mismatch
+expected:
+$EXPECTED
+actual:
+$ACTUAL"
+fi
+echo "ok:"
+echo "$ACTUAL"
+
+echo
+echo "== 3. file contents should match =="
+grep -q "Hello from a big-endian Xbox 360 filesystem." "$MNT/HELLO.TXT" \
+    || fail "HELLO.TXT content is wrong: $(cat "$MNT/HELLO.TXT" | head -c 80)"
+
+python3 - "$MNT/GAMES/COVER.JPG" <<'EOF' || fail "COVER.JPG content is wrong"
+import sys
+expected = bytes(range(256)) * 8
+with open(sys.argv[1], "rb") as f:
+    actual = f.read()
+if actual != expected:
+    print(f"length {len(actual)} vs {len(expected)}", file=sys.stderr)
+    sys.exit(1)
+EOF
+echo "ok: both files read back byte-exact"
+
+fusermount -u "$MNT"
+
+echo
+echo "== 4. explicit --variant=x360 should also work =="
+fatxfs --variant=x360 --offset=0 --size=$((16 * 1024 * 1024)) "$IMG" "$MNT"
+test -f "$MNT/GAMES/COVER.JPG" || fail "explicit variant mount is missing files"
+echo "ok"
+fusermount -u "$MNT"
+
+echo
+echo "== 5. forcing the wrong variant should be rejected, not silently wrong =="
+if fatxfs --variant=xbox --offset=0 --size=$((16 * 1024 * 1024)) \
+          --log="$WORK/wrong.log" --loglevel=4 "$IMG" "$MNT" > /dev/null 2>&1; then
+    fusermount -u "$MNT" || true
+    fail "mounting a 360 image as xbox succeeded; it should have been rejected"
+fi
+grep -qi 'invalid signature' "$WORK/wrong.log" \
+    || fail "mount failed, but not because of the signature:
+$(cat "$WORK/wrong.log")"
+echo "ok: $(grep -i 'invalid signature' "$WORK/wrong.log" | head -1)"
+
+echo
+echo "ALL X360 READ TESTS PASSED"

--- a/tests/test_x360_write.sh
+++ b/tests/test_x360_write.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Write to a synthetic big-endian (Xbox 360) FATX image and verify the result.
+#
+# Round-tripping through libfatx is not enough on its own: a driver that
+# byte-swaps consistently but wrongly reads back everything it wrote and looks
+# perfectly healthy. So after every write this also decodes the raw image with
+# verify_x360_dirents.py, which shares no code with the library.
+#
+# Requires fatxfs on PATH.
+
+set -eu
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+MNT="$WORK/mnt"
+IMG="$WORK/x360.img"
+SIZE=$((16 * 1024 * 1024))
+
+# Geometry of the synthetic image, needed by the raw decoder.
+CLUSTER_OFFSET=8192
+BYTES_PER_CLUSTER=16384
+
+cleanup() {
+    if mountpoint -q "$MNT" 2>/dev/null; then
+        fusermount -u "$MNT" || true
+    fi
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mount_rw() {
+    fatxfs --variant=x360 --offset=0 --size=$SIZE "$IMG" "$MNT"
+    # fatxfs backgrounds itself; wait for the mount to become live.
+    for _ in $(seq 1 50); do
+        mountpoint -q "$MNT" && return 0
+        sleep 0.1
+    done
+    fail "mount did not come up"
+}
+
+unmount() {
+    fusermount -u "$MNT"
+    for _ in $(seq 1 50); do
+        mountpoint -q "$MNT" || return 0
+        sleep 0.1
+    done
+    fail "unmount did not complete"
+}
+
+verify_raw() {
+    python3 "$HERE/verify_x360_dirents.py" "$IMG" "$CLUSTER_OFFSET" "$BYTES_PER_CLUSTER" \
+        || fail "$1: raw image does not decode as valid Xbox 360 data"
+}
+
+mkdir -p "$MNT"
+python3 "$HERE/make_x360_image.py" "$IMG" > /dev/null
+
+echo "== 1. create a file, a directory, and a nested file =="
+mount_rw
+echo "written by libfatx" > "$MNT/NEW.TXT"
+mkdir "$MNT/NEWDIR"
+echo "nested" > "$MNT/NEWDIR/INNER.TXT"
+unmount
+verify_raw "after create"
+echo "ok"
+
+echo
+echo "== 2. a multi-cluster file, to exercise FAT chain writing =="
+# 100 KiB spans seven 16 KiB clusters, so the chain has to be built and walked.
+mount_rw
+head -c 102400 /dev/urandom > "$WORK/big.bin"
+cp "$WORK/big.bin" "$MNT/BIG.BIN"
+unmount
+verify_raw "after multi-cluster write"
+
+mount_rw
+cmp "$MNT/BIG.BIN" "$WORK/big.bin" || fail "multi-cluster file did not survive a remount"
+unmount
+echo "ok: 100 KiB across 7 clusters, byte-exact after remount"
+
+echo
+echo "== 3. pre-existing data must be untouched =="
+mount_rw
+grep -q "Hello from a big-endian Xbox 360 filesystem." "$MNT/HELLO.TXT" \
+    || fail "HELLO.TXT was damaged by the writes"
+[ "$(cat "$MNT/NEWDIR/INNER.TXT")" = "nested" ] || fail "nested file lost"
+unmount
+echo "ok"
+
+echo
+echo "== 4. rename and delete =="
+mount_rw
+mv "$MNT/NEW.TXT" "$MNT/RENAMED.TXT"
+rm "$MNT/BIG.BIN"
+unmount
+verify_raw "after rename and delete"
+
+mount_rw
+[ -f "$MNT/RENAMED.TXT" ] || fail "rename did not persist"
+[ ! -f "$MNT/NEW.TXT" ] || fail "old name still present after rename"
+[ ! -f "$MNT/BIG.BIN" ] || fail "deleted file still present"
+unmount
+echo "ok"
+
+echo
+echo "== 5. timestamps written must round-trip through the raw decoder =="
+mount_rw
+touch -d "2026-08-11 23:50:30" "$MNT/RENAMED.TXT"
+unmount
+verify_raw "after touch"
+mount_rw
+STAMP="$(date -d @"$(stat -c %Y "$MNT/RENAMED.TXT")" '+%Y-%m-%d %H:%M:%S')"
+[ "$STAMP" = "2026-08-11 23:50:30" ] \
+    || fail "timestamp came back as $STAMP, expected 2026-08-11 23:50:30"
+unmount
+echo "ok: $STAMP"
+
+echo
+echo "== 6. a read-only mount must refuse to write =="
+fatxfs --variant=x360 --read-only --offset=0 --size=$SIZE "$IMG" "$MNT"
+if touch "$MNT/SHOULD_NOT_APPEAR" 2>/dev/null; then
+    unmount
+    fail "read-only mount accepted a write"
+fi
+unmount
+echo "ok"
+
+echo
+echo "== 7. final state, decoded independently =="
+python3 "$HERE/verify_x360_dirents.py" "$IMG" "$CLUSTER_OFFSET" "$BYTES_PER_CLUSTER"
+
+echo
+echo "ALL X360 WRITE TESTS PASSED"

--- a/tests/verify_x360_dirents.py
+++ b/tests/verify_x360_dirents.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+#
+# FATX Filesystem Library
+#
+# Copyright (C) 2026  Mijael Viricochea
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Decode the directory entries of an Xbox 360 FATX image, independently.
+
+This exists to check the *write* path. A filesystem driver that byte-swaps
+consistently but wrongly will read back everything it wrote and look perfectly
+healthy, so round-tripping through libfatx proves nothing about whether the
+bytes on disk are what an Xbox 360 would actually write.
+
+This parser shares no code with libfatx. It decodes straight from the format:
+big-endian fields, timestamps with a 1980 epoch, standard FAT hour and minute
+widths, and the date stored before the time in each pair.
+
+Usage: verify_x360_dirents.py <image> [cluster-offset] [bytes-per-cluster]
+"""
+
+import calendar
+import struct
+import sys
+
+DIRENT_SIZE = 64
+END_MARKERS = (0x00, 0xFF)
+DELETED_MARKER = 0xE5
+ATTR_DIRECTORY = 0x10
+EPOCH = 1980
+
+
+def decode_date(raw):
+    return (((raw >> 9) & 0x7F) + EPOCH, (raw >> 5) & 0xF, raw & 0x1F)
+
+
+def decode_time(raw):
+    return ((raw >> 11) & 0x1F, (raw >> 5) & 0x3F, (raw & 0x1F) * 2)
+
+
+def plausible(y, mo, d, h, mi, s):
+    if not (EPOCH <= y <= EPOCH + 127 and 1 <= mo <= 12 and 1 <= d <= 31):
+        return False
+    if d > calendar.monthrange(y, mo)[1]:
+        return False
+    return h <= 23 and mi <= 59 and s <= 59
+
+
+def parse_dirents(data):
+    """Yield (name, is_dir, first_cluster, size, timestamp, ok) per entry."""
+    for i in range(len(data) // DIRENT_SIZE):
+        entry = data[i * DIRENT_SIZE:(i + 1) * DIRENT_SIZE]
+        name_len = entry[0]
+        if name_len in END_MARKERS:
+            return
+        if name_len == DELETED_MARKER:
+            continue
+
+        attributes = entry[1]
+        name = entry[2:2 + name_len].decode('ascii', 'replace')
+        first_cluster, size = struct.unpack('>II', entry[44:52])
+        # Date first, then time -- the opposite of the original Xbox.
+        date_raw, time_raw = struct.unpack('>HH', entry[52:56])
+        y, mo, d = decode_date(date_raw)
+        h, mi, s = decode_time(time_raw)
+        stamp = f'{y:04d}-{mo:02d}-{d:02d} {h:02d}:{mi:02d}:{s:02d}'
+        yield (name, bool(attributes & ATTR_DIRECTORY), first_cluster, size,
+               stamp, plausible(y, mo, d, h, mi, s))
+
+
+def check_padding(data):
+    """The filename tail must not carry leftover stack bytes."""
+    bad = []
+    for i in range(len(data) // DIRENT_SIZE):
+        entry = data[i * DIRENT_SIZE:(i + 1) * DIRENT_SIZE]
+        name_len = entry[0]
+        if name_len in END_MARKERS:
+            break
+        if name_len == DELETED_MARKER:
+            continue
+        tail = set(entry[2 + name_len:44])
+        if tail and not tail.issubset({0x00, 0xFF}):
+            bad.append(entry[2:2 + name_len].decode('ascii', 'replace'))
+    return bad
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f'usage: {sys.argv[0]} <image> [cluster-offset] [bytes-per-cluster]',
+              file=sys.stderr)
+        return 2
+
+    path = sys.argv[1]
+    cluster_offset = int(sys.argv[2], 0) if len(sys.argv) > 2 else 8192
+    bytes_per_cluster = int(sys.argv[3], 0) if len(sys.argv) > 3 else 16384
+
+    with open(path, 'rb') as f:
+        f.seek(cluster_offset)
+        root = f.read(bytes_per_cluster)
+
+    failures = 0
+    print(f'{"name":<24} {"kind":<5} {"cluster":>8} {"size":>10}  timestamp')
+    print('-' * 74)
+    for name, is_dir, cluster, size, stamp, ok in parse_dirents(root):
+        flag = '' if ok else '   <-- IMPLAUSIBLE TIMESTAMP'
+        if not ok:
+            failures += 1
+        kind = 'dir' if is_dir else 'file'
+        print(f'{name:<24} {kind:<5} {cluster:>8} {size:>10}  {stamp}{flag}')
+
+    bad_padding = check_padding(root)
+    if bad_padding:
+        failures += 1
+        print(f'\nFAIL: filename padding carries junk in: {", ".join(bad_padding)}')
+
+    print()
+    if failures:
+        print(f'FAILED: {failures} problem(s)')
+        return 1
+
+    print('OK: every entry decodes as valid Xbox 360 on-disk data')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This adds Xbox 360 support — this library already had a working FUSE driver with full read/write support, but it only ever worked on original Xbox disks, because nothing in it handled byte order. The 360 uses the exact same filesystem, just written the other way around, so it silently failed (or worse, silently corrupted things) on 360 drives.

Original Xbox support isn't touched by any of this — same behavior, same tests all still passing.

## What's actually different on a 360

Turns out it's not just "flip the bytes." Once I had this reading a real console-formatted drive, I found four separate things the 360 does differently, and all four had to be fixed before anything decoded correctly:

- Numbers are stored big-endian instead of little-endian.
- Timestamps count from 1980 instead of 2000.
- The hour/minute fields are wider (standard FAT sizing, not the original Xbox's cramped version).
- The date and time are swapped — date comes first.

I found these by comparing against files that were actually written by a real console (some dated to the console's 2005 launch day), not just by reading the spec. A couple of these would have quietly produced wrong-but-plausible-looking dates if I hadn't checked against real hardware.

The library figures out which kind of disk it's looking at automatically (it can tell from the partition signature), so nothing about how you use it changes if you're still on an original Xbox.

## Other things that came out of this

- Found and fixed two actual bugs that were affecting the original Xbox too: directory entries were leaking bits of uninitialized memory onto disk, and timestamps could be off by an hour depending on daylight saving.
- Added a proper read-only mode — before this, telling FUSE "read only" didn't actually stop the driver from being able to write to the device underneath, which felt too risky when the "device" in question is someone's only copy of their console's hard drive.
- Made mounting work through fstab/`mount -o` the normal way, and added a package for installing it that way.
- Ported all of this to the Python bindings and the in-progress Rust version too, so nothing is 360-only in the C code and stuck everywhere else.

## How I know it actually works

I didn't want to just trust that the driver could read back what it wrote — that only proves it's consistent with itself, not that it's right. So:

- I wrote a completely separate script that decodes the raw bytes by hand, with no shared code, and used that to double check everything the driver wrote.
- I ran the whole thing against a real 1TB 360 hard drive — reading the entire real disk, and doing writes in an isolated test folder.
- Then, the part that actually matters: I put the drive back in an Xbox 360 and had the console itself read back the files this wrote. It saw them, with correct names and timestamps, and the file contents matched byte for byte. Nothing that was already on the drive was touched.

So this isn't just "looks right on paper" — an actual console has read data this wrote.
